### PR TITLE
Fix macOS crash on quit

### DIFF
--- a/markitdowngui/ui_qml/app.py
+++ b/markitdowngui/ui_qml/app.py
@@ -39,8 +39,15 @@ def main() -> int:
 
     QTimer.singleShot(500, controller.checkLastPackagedUpdateResult)
     QTimer.singleShot(2000, controller.startAutomaticUpdateCheck)
-    app.aboutToQuit.connect(controller.shutdown)
+    # aboutToQuit has no return value, while shutdown returns whether a QML
+    # close request should be accepted. Connecting the typed Boolean slot
+    # directly crashes PySide on macOS when it tries to marshal that result.
+    app.aboutToQuit.connect(lambda: _shutdown_without_result(controller))
     return app.exec()
+
+
+def _shutdown_without_result(controller: AppController) -> None:
+    controller.shutdown()
 
 
 def _configure_style() -> None:

--- a/tests/ui_qml/test_app.py
+++ b/tests/ui_qml/test_app.py
@@ -1,0 +1,14 @@
+from unittest.mock import Mock
+
+from markitdowngui.ui_qml.app import _shutdown_without_result
+from markitdowngui.ui_qml.controller import AppController
+
+
+def test_shutdown_without_result_discards_close_decision():
+    controller = Mock(spec=AppController)
+    controller.shutdown.return_value = True
+
+    result = _shutdown_without_result(controller)
+
+    assert result is None
+    controller.shutdown.assert_called_once_with()


### PR DESCRIPTION
## Summary

- route aboutToQuit through a return-less wrapper instead of the Boolean QML close slot
- prevent PySide from marshalling a Boolean result for a void Qt signal
- add a regression test for the shutdown wrapper

## Verification

- Native Apple Silicon quit probe: status 139 before the fix; five consecutive status 0 exits after the fix
- uv run --frozen --extra test pytest -q: 233 passed
- uv run --frozen --extra test python -m compileall -q markitdowngui tests
- git diff --check

Closes #44