### PR TITLE
feat(desktop): harden conversion workflow

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 Jonas / imadreamerboy
+Copyright (c) 2025-2026 Jonas / imadreamerboy
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -192,9 +192,14 @@ That build intentionally excludes the GLM-OCR self-hosted runtime stack; local h
 
 ## License
 
-Licensed under the **MIT License**.
+MarkItDown GUI is licensed under the **MIT License**. Commercial use, private
+use, modification, redistribution, sublicensing, and sale are permitted under
+that licence, subject to preserving the copyright and licence notice.
 
-The app uses `PySide6`/Qt under Qt's LGPL/commercial licensing model. The previous `PySide6-Fluent-Widgets` dependency has been removed.
+Third-party components keep their own licences. The app uses `PySide6`/Qt under
+Qt's LGPL/commercial licensing model; see
+[`THIRD_PARTY_NOTICES.md`](THIRD_PARTY_NOTICES.md) for the runtime and
+dependency notices that apply to source and packaged builds.
 
 ## Contributing
 
@@ -219,4 +224,5 @@ uv run pytest -q
 - MarkItDown ([MIT License](https://opensource.org/licenses/MIT))
 - PySide6 ([LGPLv3 License](https://www.gnu.org/licenses/lgpl-3.0.html))
 - Qt Quick Controls ([Qt documentation](https://doc.qt.io/qt-6/qtquickcontrols-index.html))
+- Lucide icons ([ISC License](https://lucide.dev/license))
 

--- a/README.md
+++ b/README.md
@@ -18,13 +18,13 @@ More screenshots:
 
 - Queue-based file workflow with drag and drop.
 - Paste website URLs and convert article content to Markdown with the hosted Defuddle API.
-- Batch conversion with start, pause/resume, cancel, and progress feedback.
+- Serial conversion with start, pause/resume, cancel, and progress feedback.
 - Results view with per-file selection and Markdown preview.
 - Preview modes: rendered Markdown view and raw Markdown view.
 - Save modes: export as one combined file or separate files.
 - Quick actions: copy Markdown, save output, retry failed conversions, back to queue, start over.
 - Optional OCR for scanned PDFs and image files, with selectable `Azure + Tesseract`, `GLM-OCR`, and generic `HTTP OCR` providers.
-- Settings for output folder, save mode, source-folder saves, batch size, OCR, and theme mode (light/dark/system).
+- Settings for output folder, save mode, source-folder saves, OCR, and theme mode (light/dark/system).
 - Help view with project links, OCR references, conversion references, and keyboard shortcuts.
 
 ## Installation
@@ -182,7 +182,7 @@ uv run python -m markitdowngui.main
 ## Build a Standalone Executable
 
 ```sh
-uv pip install -e .[dev]
+uv sync --extra dev --locked
 pyinstaller MarkItDown.spec --clean --noconfirm
 ```
 
@@ -214,6 +214,7 @@ uv pip install -e .[dev]
 4. Run tests:
 
 ```sh
+uv sync --extra test --locked
 uv run pytest -q
 ```
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -192,9 +192,12 @@ Release workflow 会把 Windows 和 Linux build 打包为平台专属 `.zip`，�
 
 ## 许可证
 
-本项目采用 **MIT License**。
+MarkItDown GUI 采用 **MIT License**。该许可证允许商业使用、私有使用、修改、
+再分发、再授权和销售，但需要保留版权和许可证声明。
 
-应用使用 `PySide6`/Qt，需遵守 Qt 的 LGPL/商业许可模式。此前的 `PySide6-Fluent-Widgets` 依赖已移除。
+第三方组件仍适用各自的许可证。应用使用 `PySide6`/Qt，需遵守 Qt 的
+LGPL/商业许可模式；源码和打包版本适用的运行时与依赖声明见
+[`THIRD_PARTY_NOTICES.md`](THIRD_PARTY_NOTICES.md)。
 
 ## 贡献
 
@@ -219,3 +222,4 @@ uv run pytest -q
 - MarkItDown ([MIT License](https://opensource.org/licenses/MIT))
 - PySide6 ([LGPLv3 License](https://www.gnu.org/licenses/lgpl-3.0.html))
 - Qt Quick Controls ([Qt documentation](https://doc.qt.io/qt-6/qtquickcontrols-index.html))
+- Lucide icons ([ISC License](https://lucide.dev/license))

--- a/README_zh_TW.md
+++ b/README_zh_TW.md
@@ -192,9 +192,12 @@ Release workflow 會把 Windows 和 Linux build 打包成平台專屬 `.zip`，�
 
 ## 授權
 
-本專案採用 **MIT License**。
+MarkItDown GUI 採用 **MIT License**。該授權允許商業使用、私人使用、修改、
+再散布、再授權和銷售，但需要保留版權和授權聲明。
 
-應用使用 `PySide6`/Qt，需遵守 Qt 的 LGPL/商業授權模式。此前的 `PySide6-Fluent-Widgets` 相依套件已移除。
+第三方元件仍適用各自的授權。應用程式使用 `PySide6`/Qt，需遵守 Qt 的
+LGPL/商業授權模式；原始碼和打包版本適用的執行環境與相依套件聲明請見
+[`THIRD_PARTY_NOTICES.md`](THIRD_PARTY_NOTICES.md)。
 
 ## 貢獻
 
@@ -219,3 +222,4 @@ uv run pytest -q
 - MarkItDown ([MIT License](https://opensource.org/licenses/MIT))
 - PySide6 ([LGPLv3 License](https://www.gnu.org/licenses/lgpl-3.0.html))
 - Qt Quick Controls ([Qt documentation](https://doc.qt.io/qt-6/qtquickcontrols-index.html))
+- Lucide icons ([ISC License](https://lucide.dev/license))

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -1,0 +1,60 @@
+# Third-Party Notices
+
+MarkItDown GUI is licensed under the MIT License. Commercial use, private use,
+modification, redistribution, sublicensing, and sale are permitted under that
+licence, subject to preserving the copyright and licence notice.
+
+This file summarises notable third-party components used by the application.
+Each component remains under its own licence. Where a packaged build bundles a
+runtime or library, distributors must also satisfy that component's licence
+terms.
+
+## Runtime And UI
+
+- PySide6, PySide6 Addons, PySide6 Essentials, and shiboken6: LGPL-3.0-only OR
+  GPL-2.0-only OR GPL-3.0-only, with a commercial Qt licensing option. The app
+  uses Qt through PySide6 and does not modify Qt itself.
+- Qt Quick and Qt Quick Controls: Qt modules used through PySide6. When
+  distributing binaries under the LGPL route, keep the relevant Qt/PySide
+  notices available and do not prevent users from replacing the LGPL-covered Qt
+  libraries with compatible modified versions.
+- Lucide icons: ISC License for the icon set. The bundled icon subset includes
+  `markitdowngui/resources/icons/LICENSE.lucide.txt`.
+
+## Conversion, OCR, And Document Processing
+
+- MarkItDown: MIT License.
+- markitdown-pdf-images: MIT License.
+- Docling Core and Docling Parse: MIT License for the codebases; any model usage
+  remains subject to the applicable model licences.
+- GLM-OCR Python package: Apache-2.0 License.
+- pytesseract: Apache-2.0 License. Tesseract OCR itself is an external runtime
+  when installed separately by the user.
+- pypdfium2: BSD-3-Clause, Apache-2.0, and dependency licences.
+- pdfminer.six: MIT License.
+- pdfplumber: MIT License.
+- mammoth: BSD-2-Clause License.
+- markdownify: MIT License.
+- Beautiful Soup: MIT License.
+- lxml: BSD-3-Clause License.
+- python-pptx: MIT License.
+- pandas: BSD-3-Clause License.
+- openpyxl: MIT License.
+- xlrd: BSD License.
+- Azure AI Document Intelligence SDK and Azure Identity SDK: MIT License.
+
+## Services And External Tools
+
+- Azure Document Intelligence, GLM-OCR hosted/API modes, Defuddle, Ollama, and
+  Tesseract installations are external services or tools when configured by the
+  user. Their service terms, model terms, billing terms, and local installation
+  licences are separate from the MarkItDown GUI project licence.
+
+## Notes For Binary Distribution
+
+- Include `LICENSE` and this `THIRD_PARTY_NOTICES.md` file with packaged builds.
+- Preserve third-party licence files that are bundled inside dependency wheels
+  or copied runtime folders.
+- If distributing under Qt's LGPL path rather than a Qt commercial licence,
+  verify that the package layout continues to allow replacement of the
+  LGPL-covered Qt/PySide libraries.

--- a/markitdowngui/build_config.py
+++ b/markitdowngui/build_config.py
@@ -52,6 +52,7 @@ BASE_DATAS = (
     ("markitdowngui/resources/moon.svg", "markitdowngui/resources"),
     ("markitdowngui/resources/sun.svg", "markitdowngui/resources"),
     ("LICENSE", "."),
+    ("THIRD_PARTY_NOTICES.md", "."),
 )
 OPTIONAL_DATA_PACKAGES = (
     "docling_parse",

--- a/markitdowngui/core/conversion.py
+++ b/markitdowngui/core/conversion.py
@@ -275,6 +275,37 @@ class ConversionOutcome:
     assets: list[ConversionAsset] = field(default_factory=list)
 
 
+class MarkItDownSession:
+    """Lazily reuse native MarkItDown instances within one serial worker."""
+
+    def __init__(self) -> None:
+        self._instances: dict[tuple[bool, str], object] = {}
+
+    def get(
+        self,
+        options: ConversionOptions,
+        *,
+        use_docintel: bool = False,
+    ) -> object:
+        endpoint = options.normalized_docintel_endpoint if use_docintel else ""
+        key = (use_docintel, endpoint)
+        instance = self._instances.get(key)
+        if instance is not None:
+            return instance
+
+        # Delay the heavy import until a native conversion is actually requested.
+        from markitdown import MarkItDown
+
+        kwargs: dict[str, object] = {}
+        if use_docintel and endpoint:
+            kwargs["docintel_endpoint"] = endpoint
+            kwargs["docintel_credential"], _auth_method = _build_docintel_credential()
+
+        instance = MarkItDown(**kwargs)
+        self._instances[key] = instance
+        return instance
+
+
 def format_conversion_error(file_path: str, error: Exception) -> str:
     return f"{CONVERSION_ERROR_PREFIX}{file_path}: {error}"
 
@@ -617,6 +648,8 @@ def _test_http_endpoint_reachable(
 def convert_file_with_details(
     file_path: str,
     options: ConversionOptions | None = None,
+    *,
+    markitdown_session: MarkItDownSession | None = None,
 ) -> ConversionOutcome:
     """Convert a single file to Markdown text and report which backend produced it."""
     effective_options = options or ConversionOptions()
@@ -637,7 +670,11 @@ def convert_file_with_details(
 
     if not effective_options.ocr_enabled:
         return ConversionOutcome(
-            markdown=_convert_with_markitdown(file_path, effective_options),
+            markdown=_convert_with_markitdown_for_session(
+                file_path,
+                effective_options,
+                markitdown_session=markitdown_session,
+            ),
             backend=BACKEND_NATIVE,
         )
 
@@ -648,7 +685,11 @@ def convert_file_with_details(
         return _convert_pdf_with_ocr(file_path, effective_options)
 
     return ConversionOutcome(
-        markdown=_convert_with_markitdown(file_path, effective_options),
+        markdown=_convert_with_markitdown_for_session(
+            file_path,
+            effective_options,
+            markitdown_session=markitdown_session,
+        ),
         backend=BACKEND_NATIVE,
     )
 
@@ -1039,18 +1080,43 @@ def _convert_with_markitdown(
     options: ConversionOptions,
     *,
     use_docintel: bool = False,
+    markitdown_session: MarkItDownSession | None = None,
 ) -> str:
-    # Delay heavy imports until conversion is requested.
-    from markitdown import MarkItDown
+    if markitdown_session is not None:
+        md = markitdown_session.get(options, use_docintel=use_docintel)
+    else:
+        # Delay heavy imports until conversion is requested.
+        from markitdown import MarkItDown
 
-    kwargs: dict[str, object] = {}
-    if use_docintel and options.normalized_docintel_endpoint:
-        kwargs["docintel_endpoint"] = options.normalized_docintel_endpoint
-        kwargs["docintel_credential"], _auth_method = _build_docintel_credential()
-
-    md = MarkItDown(**kwargs)
+        kwargs: dict[str, object] = {}
+        if use_docintel and options.normalized_docintel_endpoint:
+            kwargs["docintel_endpoint"] = options.normalized_docintel_endpoint
+            kwargs["docintel_credential"], _auth_method = _build_docintel_credential()
+        md = MarkItDown(**kwargs)
     result = md.convert(file_path)
     return result.text_content or ""
+
+
+def _convert_with_markitdown_for_session(
+    file_path: str,
+    options: ConversionOptions,
+    *,
+    use_docintel: bool = False,
+    markitdown_session: MarkItDownSession | None = None,
+) -> str:
+    """Keep existing converter hooks compatible when no worker session is active."""
+    if markitdown_session is None:
+        return _convert_with_markitdown(
+            file_path,
+            options,
+            use_docintel=use_docintel,
+        )
+    return _convert_with_markitdown(
+        file_path,
+        options,
+        use_docintel=use_docintel,
+        markitdown_session=markitdown_session,
+    )
 
 
 def _convert_with_glmocr(
@@ -1443,6 +1509,7 @@ def _run_tesseract_ocr(image, options: ConversionOptions) -> str:
 
 class ConversionWorker(QThread):
     progress = Signal(int, str)
+    itemFinished = Signal(str, object, bool)
     finished = Signal(dict)
     error = Signal(str)
 
@@ -1454,6 +1521,8 @@ class ConversionWorker(QThread):
     ):
         super().__init__()
         self.files = files
+        # Retained for callers/settings profiles created before serial scheduling.
+        # A batch boundary never produced concurrency, so it no longer affects work.
         self.batch_size = batch_size
         self.options = options or ConversionOptions()
         self.failed_files: set[str] = set()
@@ -1465,33 +1534,33 @@ class ConversionWorker(QThread):
         results: dict[str, ConversionOutcome] = {}
         self.failed_files = set()
         self.processing_backends = {}
+        markitdown_session = MarkItDownSession()
 
-        for i in range(0, len(self.files), self.batch_size):
-            if self.is_cancelled:
-                break
-
-            batch = self.files[i : i + self.batch_size]
-            for j, file_path in enumerate(batch):
-                while self.is_paused:
-                    if self.is_cancelled:
-                        break
-                    self.msleep(100)
+        for index, file_path in enumerate(self.files):
+            while self.is_paused:
                 if self.is_cancelled:
                     break
-
-                try:
-                    outcome = convert_file_with_details(file_path, self.options)
-                    results[file_path] = outcome
-                    self.processing_backends[file_path] = outcome.backend
-                except Exception as exc:
-                    self.failed_files.add(file_path)
-                    results[file_path] = ConversionOutcome(
-                        markdown=format_conversion_error(file_path, exc)
-                    )
-
-                progress = int((i + j + 1) / len(self.files) * 100)
-                self.progress.emit(progress, file_path)
+                self.msleep(100)
             if self.is_cancelled:
                 break
+
+            failed = False
+            try:
+                outcome = convert_file_with_details(
+                    file_path,
+                    self.options,
+                    markitdown_session=markitdown_session,
+                )
+                results[file_path] = outcome
+                self.processing_backends[file_path] = outcome.backend
+            except Exception as exc:
+                failed = True
+                self.failed_files.add(file_path)
+                outcome = ConversionOutcome(markdown=format_conversion_error(file_path, exc))
+                results[file_path] = outcome
+
+            self.itemFinished.emit(file_path, outcome, failed)
+            progress = int((index + 1) / len(self.files) * 100)
+            self.progress.emit(progress, file_path)
 
         self.finished.emit(results)

--- a/markitdowngui/core/file_utils.py
+++ b/markitdowngui/core/file_utils.py
@@ -64,6 +64,8 @@ class FileManager:
     def stage_markdown_file(filepath: str, content: str) -> StagedMarkdownFile:
         """Write Markdown beside its destination without replacing the current file."""
         destination = Path(filepath)
+        if destination.is_symlink():
+            destination = destination.resolve()
         destination.parent.mkdir(parents=True, exist_ok=True)
         descriptor, temporary_path = _create_staged_file(destination)
         try:
@@ -97,7 +99,7 @@ class FileManager:
 def _create_staged_file(destination: Path) -> tuple[int, str]:
     """Create an exclusive staged file using the user's normal file mode."""
     for _ in range(10):
-        temporary_path = destination.parent / f".{destination.name}.{token_hex(16)}.tmp"
+        temporary_path = destination.parent / f".markitdowngui-{token_hex(16)}.tmp"
         try:
             descriptor = os.open(
                 temporary_path,

--- a/markitdowngui/core/file_utils.py
+++ b/markitdowngui/core/file_utils.py
@@ -1,6 +1,24 @@
 import os
+from dataclasses import dataclass
+from pathlib import Path
+import tempfile
 from datetime import datetime
 from typing import List, Dict
+
+
+@dataclass
+class StagedMarkdownFile:
+    """A fully-written Markdown file awaiting an atomic replacement."""
+
+    destination: Path
+    temporary_path: Path
+
+    def commit(self) -> None:
+        os.replace(self.temporary_path, self.destination)
+
+    def abort(self) -> None:
+        if self.temporary_path.exists():
+            self.temporary_path.unlink()
 
 class FileManager:
     """Handles file operations and tracking of recent files."""
@@ -34,9 +52,33 @@ class FileManager:
 
     @staticmethod
     def save_markdown_file(filepath: str, content: str) -> None:
-        """Save markdown content to a file."""
-        with open(filepath, "w", encoding="utf-8") as f:
-            f.write(content)
+        """Atomically replace a Markdown file after its full contents are written."""
+        staged_file = FileManager.stage_markdown_file(filepath, content)
+        try:
+            staged_file.commit()
+        finally:
+            staged_file.abort()
+
+    @staticmethod
+    def stage_markdown_file(filepath: str, content: str) -> StagedMarkdownFile:
+        """Write Markdown beside its destination without replacing the current file."""
+        destination = Path(filepath)
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        descriptor, temporary_path = tempfile.mkstemp(
+            prefix=f".{destination.name}.",
+            suffix=".tmp",
+            dir=destination.parent,
+        )
+        try:
+            with os.fdopen(descriptor, "w", encoding="utf-8") as handle:
+                handle.write(content)
+                handle.flush()
+                os.fsync(handle.fileno())
+        except Exception:
+            if os.path.exists(temporary_path):
+                os.unlink(temporary_path)
+            raise
+        return StagedMarkdownFile(destination, Path(temporary_path))
 
     @staticmethod
     def update_recent_list(filepath: str, recent_list: List[str], max_items: int = 10) -> List[str]:

--- a/markitdowngui/core/file_utils.py
+++ b/markitdowngui/core/file_utils.py
@@ -1,7 +1,8 @@
 import os
 from dataclasses import dataclass
 from pathlib import Path
-import tempfile
+import stat
+from secrets import token_hex
 from datetime import datetime
 from typing import List, Dict
 
@@ -64,22 +65,26 @@ class FileManager:
         """Write Markdown beside its destination without replacing the current file."""
         destination = Path(filepath)
         destination.parent.mkdir(parents=True, exist_ok=True)
-        descriptor, temporary_path = tempfile.mkstemp(
-            prefix=f".{destination.name}.",
-            suffix=".tmp",
-            dir=destination.parent,
-        )
+        descriptor, temporary_path = _create_staged_file(destination)
         try:
+            if (
+                os.name != "nt"
+                and destination.exists()
+                and not destination.is_symlink()
+            ):
+                os.fchmod(descriptor, stat.S_IMODE(destination.stat().st_mode))
             with os.fdopen(descriptor, "w", encoding="utf-8") as handle:
+                descriptor = -1
                 handle.write(content)
                 handle.flush()
                 os.fsync(handle.fileno())
         except Exception:
+            if descriptor != -1:
+                os.close(descriptor)
             if os.path.exists(temporary_path):
                 os.unlink(temporary_path)
             raise
         return StagedMarkdownFile(destination, Path(temporary_path))
-
     @staticmethod
     def update_recent_list(filepath: str, recent_list: List[str], max_items: int = 10) -> List[str]:
         """Update a list of recent files."""
@@ -87,3 +92,19 @@ class FileManager:
             recent_list.remove(filepath)
         recent_list.insert(0, filepath)
         return recent_list[:max_items]
+
+
+def _create_staged_file(destination: Path) -> tuple[int, str]:
+    """Create an exclusive staged file using the user's normal file mode."""
+    for _ in range(10):
+        temporary_path = destination.parent / f".{destination.name}.{token_hex(16)}.tmp"
+        try:
+            descriptor = os.open(
+                temporary_path,
+                os.O_WRONLY | os.O_CREAT | os.O_EXCL,
+                0o666,
+            )
+        except FileExistsError:
+            continue
+        return descriptor, str(temporary_path)
+    raise FileExistsError(f"Could not create a temporary Markdown file for {destination}")

--- a/markitdowngui/core/markdown_assets.py
+++ b/markitdowngui/core/markdown_assets.py
@@ -149,7 +149,7 @@ def prepare_markdown_for_separate_save_transaction(
 ) -> PreparedMarkdownAssets:
     """Stage separate-output assets until the corresponding Markdown is ready."""
     destination_path = Path(output_path)
-    asset_root = destination_path.with_name(f"{destination_path.stem}_assets")
+    asset_root = _asset_root_for_output(destination_path)
 
     return _prepare_markdown_with_assets_transaction(
         markdown,
@@ -181,7 +181,7 @@ def prepare_combined_markdown_for_save_transaction(
 ) -> PreparedMarkdownAssets:
     """Stage combined-output assets until the corresponding Markdown is ready."""
     destination_path = Path(output_path)
-    asset_root = destination_path.with_name(f"{destination_path.stem}_assets")
+    asset_root = _asset_root_for_output(destination_path)
     parts: list[str] = []
 
     if not _documents_have_copyable_assets(documents):
@@ -272,6 +272,20 @@ def _assets_have_copyable_sources(assets: Sequence[AssetLike]) -> bool:
 
 def _documents_have_copyable_assets(documents: Sequence[MarkdownSaveInput]) -> bool:
     return any(_assets_have_copyable_sources(document.assets) for document in documents)
+
+
+def _asset_root_for_output(destination_path: Path) -> Path:
+    primary_root = destination_path.with_name(f"{destination_path.stem}_assets")
+    if not _asset_root_exists(primary_root) or _is_app_owned_asset_root(primary_root):
+        return primary_root
+
+    for index in range(1, 10_000):
+        candidate = primary_root.with_name(f"{primary_root.name}_{index}")
+        if not _asset_root_exists(candidate) or _is_app_owned_asset_root(candidate):
+            return candidate
+    raise FileExistsError(
+        f"Could not find a free asset directory beside {destination_path}"
+    )
 
 
 def _create_asset_root_staging_directory(asset_root: Path) -> Path:

--- a/markitdowngui/core/markdown_assets.py
+++ b/markitdowngui/core/markdown_assets.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 import json
+import os
 from pathlib import Path
 import shutil
 import tempfile
@@ -275,13 +276,24 @@ def _documents_have_copyable_assets(documents: Sequence[MarkdownSaveInput]) -> b
 
 def _create_asset_root_staging_directory(asset_root: Path) -> Path:
     asset_root.parent.mkdir(parents=True, exist_ok=True)
-    return Path(
+    staging_root = Path(
         tempfile.mkdtemp(
             prefix=f".{asset_root.name}.",
             suffix=".staging",
             dir=asset_root.parent,
         )
     )
+    if os.name == "nt":
+        return staging_root
+
+    current_umask = os.umask(0)
+    os.umask(current_umask)
+    try:
+        staging_root.chmod(0o777 & ~current_umask)
+    except Exception:
+        shutil.rmtree(staging_root, ignore_errors=True)
+        raise
+    return staging_root
 
 
 def _ensure_asset_root_can_be_replaced(asset_root: Path) -> None:

--- a/markitdowngui/core/markdown_assets.py
+++ b/markitdowngui/core/markdown_assets.py
@@ -1,12 +1,21 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+import json
 from pathlib import Path
 import shutil
 import tempfile
 from typing import Protocol, Sequence
+from uuid import uuid4
 
 from markitdowngui.core.input_sources import source_output_stem
+
+
+_ASSET_ROOT_MARKER = ".markitdowngui-assets.json"
+_ASSET_ROOT_MANIFEST = {
+    "format": "markitdowngui-assets",
+    "version": 1,
+}
 
 
 class AssetLike(Protocol):
@@ -20,6 +29,81 @@ class MarkdownSaveInput:
     source: str
     markdown: str
     assets: Sequence[AssetLike]
+
+
+@dataclass
+class PreparedMarkdownAssets:
+    """Staged asset changes that can be committed with a Markdown file write."""
+
+    markdown: str
+    asset_root: Path
+    staging_root: Path | None = None
+    remove_owned_asset_root: bool = False
+    _backup_root: Path | None = None
+    _assets_committed: bool = False
+    _new_asset_root_committed: bool = False
+    _finalized: bool = False
+
+    def commit_assets(self) -> None:
+        """Activate staged assets while retaining the previous owned root for rollback."""
+        if self._assets_committed:
+            return
+        if self.staging_root is None and not self.remove_owned_asset_root:
+            self._assets_committed = True
+            return
+
+        _ensure_asset_root_can_be_replaced(self.asset_root)
+        backup_root: Path | None = None
+        if _asset_root_exists(self.asset_root):
+            backup_root = _asset_root_backup_path(self.asset_root)
+            self.asset_root.replace(backup_root)
+            self._backup_root = backup_root
+
+        try:
+            if self.staging_root is not None:
+                self.staging_root.replace(self.asset_root)
+                self.staging_root = None
+                self._new_asset_root_committed = True
+        except Exception:
+            if backup_root is not None:
+                try:
+                    backup_root.replace(self.asset_root)
+                    self._backup_root = None
+                except Exception as rollback_error:
+                    raise RuntimeError(
+                        "Could not activate the staged asset directory; "
+                        f"the previous assets remain at {backup_root}."
+                    ) from rollback_error
+            raise
+
+        self._assets_committed = True
+
+    def rollback_assets(self) -> None:
+        """Restore the pre-save asset directory after a Markdown write failure."""
+        if self._finalized:
+            return
+        try:
+            if self._assets_committed:
+                if self._new_asset_root_committed:
+                    _remove_owned_transaction_asset_root(self.asset_root)
+                    self._new_asset_root_committed = False
+                if self._backup_root is not None:
+                    self._backup_root.replace(self.asset_root)
+                    self._backup_root = None
+                self._assets_committed = False
+        finally:
+            _remove_directory_if_present(self.staging_root)
+            self.staging_root = None
+
+    def finalize_assets(self) -> None:
+        """Discard retained backup data after the Markdown replacement succeeds."""
+        if self._finalized:
+            return
+        _remove_directory_if_present(self._backup_root)
+        _remove_directory_if_present(self.staging_root)
+        self._backup_root = None
+        self.staging_root = None
+        self._finalized = True
 
 
 def create_temp_asset_root() -> Path:
@@ -48,11 +132,25 @@ def prepare_markdown_for_separate_save(
     assets: Sequence[AssetLike],
     output_path: str | Path,
 ) -> str:
+    """Prepare and immediately commit assets for legacy single-step callers."""
+    prepared = prepare_markdown_for_separate_save_transaction(
+        markdown,
+        assets,
+        output_path,
+    )
+    return _commit_prepared_markdown_assets(prepared)
+
+
+def prepare_markdown_for_separate_save_transaction(
+    markdown: str,
+    assets: Sequence[AssetLike],
+    output_path: str | Path,
+) -> PreparedMarkdownAssets:
+    """Stage separate-output assets until the corresponding Markdown is ready."""
     destination_path = Path(output_path)
     asset_root = destination_path.with_name(f"{destination_path.stem}_assets")
-    if asset_root.exists():
-        shutil.rmtree(asset_root)
-    return _copy_assets_and_rewrite_markdown(
+
+    return _prepare_markdown_with_assets_transaction(
         markdown,
         assets,
         asset_root=asset_root,
@@ -65,25 +163,183 @@ def prepare_combined_markdown_for_save(
     *,
     source_heading_template: str,
 ) -> str:
+    """Prepare and immediately commit assets for legacy single-step callers."""
+    prepared = prepare_combined_markdown_for_save_transaction(
+        documents,
+        output_path,
+        source_heading_template=source_heading_template,
+    )
+    return _commit_prepared_markdown_assets(prepared)
+
+
+def prepare_combined_markdown_for_save_transaction(
+    documents: Sequence[MarkdownSaveInput],
+    output_path: str | Path,
+    *,
+    source_heading_template: str,
+) -> PreparedMarkdownAssets:
+    """Stage combined-output assets until the corresponding Markdown is ready."""
     destination_path = Path(output_path)
     asset_root = destination_path.with_name(f"{destination_path.stem}_assets")
-    if asset_root.exists():
-        shutil.rmtree(asset_root)
     parts: list[str] = []
 
-    for index, document in enumerate(documents, start=1):
-        rewritten_markdown = _copy_assets_and_rewrite_markdown(
-            document.markdown,
-            document.assets,
+    if not _documents_have_copyable_assets(documents):
+        for document in documents:
+            parts.append(
+                source_heading_template.format(source=document.source)
+                + f"\n{document.markdown}"
+            )
+        return PreparedMarkdownAssets(
+            markdown="\n\n".join(parts),
             asset_root=asset_root,
-            document_scope=_document_scope_name(document.source, index),
-        )
-        parts.append(
-            source_heading_template.format(source=document.source)
-            + f"\n{rewritten_markdown}"
+            remove_owned_asset_root=_is_app_owned_asset_root(asset_root),
         )
 
-    return "\n\n".join(parts)
+    _ensure_asset_root_can_be_replaced(asset_root)
+    staging_root = _create_asset_root_staging_directory(asset_root)
+    try:
+        for index, document in enumerate(documents, start=1):
+            rewritten_markdown = _copy_assets_and_rewrite_markdown(
+                document.markdown,
+                document.assets,
+                asset_root=staging_root,
+                markdown_asset_root_name=asset_root.name,
+                document_scope=_document_scope_name(document.source, index),
+            )
+            parts.append(
+                source_heading_template.format(source=document.source)
+                + f"\n{rewritten_markdown}"
+            )
+
+        _write_asset_root_marker(staging_root)
+        return PreparedMarkdownAssets(
+            markdown="\n\n".join(parts),
+            asset_root=asset_root,
+            staging_root=staging_root,
+        )
+    except Exception:
+        _remove_directory_if_present(staging_root)
+        raise
+
+
+def _prepare_markdown_with_assets_transaction(
+    markdown: str,
+    assets: Sequence[AssetLike],
+    *,
+    asset_root: Path,
+) -> PreparedMarkdownAssets:
+    if not _assets_have_copyable_sources(assets):
+        return PreparedMarkdownAssets(
+            markdown=markdown,
+            asset_root=asset_root,
+            remove_owned_asset_root=_is_app_owned_asset_root(asset_root),
+        )
+
+    _ensure_asset_root_can_be_replaced(asset_root)
+    staging_root = _create_asset_root_staging_directory(asset_root)
+    try:
+        rewritten_markdown = _copy_assets_and_rewrite_markdown(
+            markdown,
+            assets,
+            asset_root=staging_root,
+            markdown_asset_root_name=asset_root.name,
+        )
+        _write_asset_root_marker(staging_root)
+        return PreparedMarkdownAssets(
+            markdown=rewritten_markdown,
+            asset_root=asset_root,
+            staging_root=staging_root,
+        )
+    except Exception:
+        _remove_directory_if_present(staging_root)
+        raise
+
+
+def _commit_prepared_markdown_assets(prepared: PreparedMarkdownAssets) -> str:
+    try:
+        prepared.commit_assets()
+    except Exception:
+        prepared.rollback_assets()
+        raise
+    prepared.finalize_assets()
+    return prepared.markdown
+
+
+def _assets_have_copyable_sources(assets: Sequence[AssetLike]) -> bool:
+    return any(asset.source_path for asset in assets)
+
+
+def _documents_have_copyable_assets(documents: Sequence[MarkdownSaveInput]) -> bool:
+    return any(_assets_have_copyable_sources(document.assets) for document in documents)
+
+
+def _create_asset_root_staging_directory(asset_root: Path) -> Path:
+    asset_root.parent.mkdir(parents=True, exist_ok=True)
+    return Path(
+        tempfile.mkdtemp(
+            prefix=f".{asset_root.name}.",
+            suffix=".staging",
+            dir=asset_root.parent,
+        )
+    )
+
+
+def _ensure_asset_root_can_be_replaced(asset_root: Path) -> None:
+    if not _asset_root_exists(asset_root):
+        return
+    if _is_app_owned_asset_root(asset_root):
+        return
+    raise FileExistsError(
+        "Refusing to replace unowned asset directory: "
+        f"{asset_root}. Rename or remove it before saving assets here."
+    )
+
+
+def _asset_root_backup_path(asset_root: Path) -> Path:
+    return asset_root.with_name(f".{asset_root.name}.{uuid4().hex}.backup")
+
+
+def _remove_owned_transaction_asset_root(asset_root: Path) -> None:
+    if not _asset_root_exists(asset_root):
+        return
+    if not _is_app_owned_asset_root(asset_root):
+        raise RuntimeError(
+            "Could not restore the previous asset directory because the new "
+            f"asset directory is no longer app-owned: {asset_root}."
+        )
+    shutil.rmtree(asset_root)
+
+
+def _asset_root_exists(asset_root: Path) -> bool:
+    return asset_root.exists() or asset_root.is_symlink()
+
+
+def _is_app_owned_asset_root(asset_root: Path) -> bool:
+    if asset_root.is_symlink() or not asset_root.is_dir():
+        return False
+
+    marker_path = asset_root / _ASSET_ROOT_MARKER
+    if marker_path.is_symlink() or not marker_path.is_file():
+        return False
+
+    try:
+        marker = json.loads(marker_path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError):
+        return False
+    return marker == _ASSET_ROOT_MANIFEST
+
+
+def _write_asset_root_marker(asset_root: Path) -> None:
+    marker_path = asset_root / _ASSET_ROOT_MARKER
+    marker_path.write_text(
+        json.dumps(_ASSET_ROOT_MANIFEST, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+def _remove_directory_if_present(path: Path | None) -> None:
+    if path and path.exists() and path.is_dir() and not path.is_symlink():
+        shutil.rmtree(path, ignore_errors=True)
 
 
 def _copy_assets_and_rewrite_markdown(
@@ -91,6 +347,7 @@ def _copy_assets_and_rewrite_markdown(
     assets: Sequence[AssetLike],
     *,
     asset_root: Path,
+    markdown_asset_root_name: str | None = None,
     document_scope: str = "",
 ) -> str:
     if not assets:
@@ -98,6 +355,8 @@ def _copy_assets_and_rewrite_markdown(
 
     replacements: dict[str, str] = {}
     used_relative_paths: set[Path] = set()
+    if not document_scope:
+        used_relative_paths.add(Path(_ASSET_ROOT_MARKER))
 
     for asset in assets:
         if not asset.source_path:
@@ -116,7 +375,10 @@ def _copy_assets_and_rewrite_markdown(
         destination_path.parent.mkdir(parents=True, exist_ok=True)
         shutil.copy2(source_path, destination_path)
         replacements[asset.preview_markdown_path] = (
-            Path(asset_root.name, *relative_path.parts).as_posix()
+            Path(
+                markdown_asset_root_name or asset_root.name,
+                *relative_path.parts,
+            ).as_posix()
         )
 
     return _replace_markdown_paths(markdown, replacements)

--- a/markitdowngui/core/markdown_assets.py
+++ b/markitdowngui/core/markdown_assets.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 import json
-import os
 from pathlib import Path
+from secrets import token_hex
 import shutil
 import tempfile
 from typing import Protocol, Sequence
@@ -276,24 +276,18 @@ def _documents_have_copyable_assets(documents: Sequence[MarkdownSaveInput]) -> b
 
 def _create_asset_root_staging_directory(asset_root: Path) -> Path:
     asset_root.parent.mkdir(parents=True, exist_ok=True)
-    staging_root = Path(
-        tempfile.mkdtemp(
-            prefix=f".{asset_root.name}.",
-            suffix=".staging",
-            dir=asset_root.parent,
+    for _ in range(10):
+        staging_root = asset_root.parent / (
+            f".markitdowngui-assets-{token_hex(16)}.staging"
         )
-    )
-    if os.name == "nt":
+        try:
+            staging_root.mkdir(mode=0o777)
+        except FileExistsError:
+            continue
         return staging_root
-
-    current_umask = os.umask(0)
-    os.umask(current_umask)
-    try:
-        staging_root.chmod(0o777 & ~current_umask)
-    except Exception:
-        shutil.rmtree(staging_root, ignore_errors=True)
-        raise
-    return staging_root
+    raise FileExistsError(
+        f"Could not create a staging asset directory for {asset_root}"
+    )
 
 
 def _ensure_asset_root_can_be_replaced(asset_root: Path) -> None:
@@ -308,7 +302,7 @@ def _ensure_asset_root_can_be_replaced(asset_root: Path) -> None:
 
 
 def _asset_root_backup_path(asset_root: Path) -> Path:
-    return asset_root.with_name(f".{asset_root.name}.{uuid4().hex}.backup")
+    return asset_root.with_name(f".markitdowngui-assets-{uuid4().hex}.backup")
 
 
 def _remove_owned_transaction_asset_root(asset_root: Path) -> None:

--- a/markitdowngui/qml/Main.qml
+++ b/markitdowngui/qml/Main.qml
@@ -870,6 +870,15 @@ ApplicationWindow {
                     }
                 }
 
+                Connections {
+                    target: app
+
+                    function onUrlQueued(url) {
+                        if (compactUrlInput.text.trim() === url)
+                            compactUrlInput.text = ""
+                    }
+                }
+
                 AppButton {
                     text: "Add webpage"
                     enabled: !app.converting

--- a/markitdowngui/qml/Main.qml
+++ b/markitdowngui/qml/Main.qml
@@ -15,7 +15,7 @@ ApplicationWindow {
     title: "MarkItDown GUI"
     color: colors.window
     font.family: Qt.platform.os === "windows" ? "Segoe UI" : Qt.platform.os === "osx" ? ".AppleSystemUIFont" : "Noto Sans"
-    onClosing: close => close.accepted = app.shutdown()
+    onClosing: close => close.accepted = app.requestShutdown()
 
     property int pageIndex: 0
     property bool dark: app.darkMode
@@ -32,16 +32,16 @@ ApplicationWindow {
         border: dark ? Qt.color("#4C566A") : Qt.color("#D8CEB5"),
         text: dark ? Qt.color("#ECEFF4") : Qt.color("#073642"),
         muted: dark ? Qt.color("#D8DEE9") : Qt.color("#586E75"),
-        subtle: dark ? Qt.color("#AEB8C8") : Qt.color("#839496"),
+        subtle: dark ? Qt.color("#AEB8C8") : Qt.color("#5D6E72"),
         accent: dark ? Qt.color("#88C0D0") : Qt.color("#687700"),
         accentAlt: dark ? Qt.color("#8FBCBB") : Qt.color("#7C6F00"),
         action: dark ? Qt.color("#88C0D0") : Qt.color("#687700"),
         actionSoft: dark ? Qt.color("#415867") : Qt.color("#E8EBC8"),
         onAccent: dark ? Qt.color("#2E3440") : Qt.color("#FDF6E3"),
         onAction: dark ? Qt.color("#2E3440") : Qt.color("#FDF6E3"),
-        danger: dark ? Qt.color("#E8949C") : Qt.color("#DC322F"),
+        danger: dark ? Qt.color("#E8949C") : Qt.color("#C82624"),
         success: dark ? Qt.color("#A3BE8C") : Qt.color("#397D54"),
-        warning: dark ? Qt.color("#EBCB8B") : Qt.color("#B58900")
+        warning: dark ? Qt.color("#EBCB8B") : Qt.color("#7A5900")
     })
 
     function requestSave() {
@@ -86,6 +86,14 @@ ApplicationWindow {
         if (index === 2)
             return "http"
         return "azure_tesseract"
+    }
+
+    function ocrProviderLabel(provider) {
+        if (provider === "glmocr")
+            return "GLM-OCR"
+        if (provider === "http")
+            return "HTTP OCR"
+        return "Azure + Tesseract"
     }
 
     function ocrFallbackIndex(provider) {
@@ -169,6 +177,68 @@ ApplicationWindow {
         onAccepted: app.saveSeparateOutputs(selectedFolder)
     }
 
+    Dialog {
+        id: discardResultsDialog
+        property string actionDescription: ""
+
+        title: "Discard unsaved results?"
+        modal: true
+        focus: true
+        width: 440
+        standardButtons: Dialog.NoButton
+        closePolicy: Popup.CloseOnEscape
+        anchors.centerIn: parent
+        onRejected: app.cancelPendingResultDiscard()
+
+        background: Rectangle {
+            radius: root.panelRadius
+            color: colors.surface
+            border.color: colors.border
+        }
+
+        contentItem: Label {
+            text: "Successful conversion results have not been saved. Save them before you "
+                + discardResultsDialog.actionDescription + ", or explicitly discard them."
+            color: colors.text
+            wrapMode: Text.WordWrap
+            padding: 4
+        }
+
+        footer: Item {
+            implicitHeight: discardResultsButtons.implicitHeight + 20
+
+            RowLayout {
+                id: discardResultsButtons
+                anchors.fill: parent
+                anchors.margins: 10
+                spacing: 8
+
+                Item {
+                    Layout.fillWidth: true
+                }
+
+                AppButton {
+                    text: "Keep results"
+                    subtle: true
+                    accentColor: colors.action
+                    textColor: colors.text
+                    onClicked: discardResultsDialog.reject()
+                }
+
+                AppButton {
+                    text: "Discard results"
+                    primary: true
+                    accentColor: colors.danger
+                    primaryTextColor: colors.onAccent
+                    onClicked: {
+                        app.discardPendingResults()
+                        discardResultsDialog.accept()
+                    }
+                }
+            }
+        }
+    }
+
     FolderDialog {
         id: outputFolderDialog
         title: "Choose output folder"
@@ -203,6 +273,15 @@ ApplicationWindow {
             toast.message = message
             toast.visible = true
             toastTimer.restart()
+        }
+
+        function onDiscardResultsRequested(actionDescription) {
+            discardResultsDialog.actionDescription = actionDescription
+            discardResultsDialog.open()
+        }
+
+        function onCloseApproved() {
+            root.close()
         }
     }
 
@@ -299,6 +378,7 @@ ApplicationWindow {
                 iconName: "x"
                 accentColor: colors.action
                 textColor: colors.muted
+                Accessible.name: "Dismiss update notification"
                 ToolTip.visible: hovered
                 ToolTip.delay: 550
                 ToolTip.text: "Dismiss"
@@ -316,7 +396,7 @@ ApplicationWindow {
     }
 
     Shortcut {
-        sequence: "Ctrl+O"
+        sequence: StandardKey.Open
         context: Qt.ApplicationShortcut
         enabled: !app.converting
         onActivated: openFileDialog.open()
@@ -341,14 +421,14 @@ ApplicationWindow {
     }
 
     Shortcut {
-        sequence: "Ctrl+S"
+        sequence: StandardKey.Save
         context: Qt.ApplicationShortcut
-        enabled: app.hasSuccessfulResults && !app.selectedResultFailed
+        enabled: app.hasSuccessfulResults
         onActivated: root.requestSave()
     }
 
     Shortcut {
-        sequence: "Ctrl+C"
+        sequence: StandardKey.Copy
         context: Qt.ApplicationShortcut
         enabled: root.pageIndex === 0 && app.hasResults && !root.focusedTextControl()
         onActivated: app.copySelectedMarkdown()
@@ -364,7 +444,7 @@ ApplicationWindow {
     Shortcut {
         sequence: "Ctrl+L"
         context: Qt.ApplicationShortcut
-        enabled: !app.converting
+        enabled: root.pageIndex === 0 && !app.converting && !root.focusedTextControl()
         onActivated: app.clearQueue()
     }
 
@@ -498,6 +578,7 @@ ApplicationWindow {
         borderColor: colors.border
         focusColor: colors.action
         textColor: selected ? colors.text : colors.muted
+        Accessible.name: text + " preview" + (selected ? ", selected" : "")
     }
 
     component UtilitySectionPanel: SectionPanel {
@@ -550,7 +631,7 @@ ApplicationWindow {
         spacing: 8
 
         MetricPill {
-            label: "FILES"
+            label: "INPUTS"
             value: app.queueCount.toString()
             backgroundColor: "transparent"
             borderColor: colors.border
@@ -780,10 +861,12 @@ ApplicationWindow {
                     accentColor: colors.accent
                     textColor: colors.text
                     placeholderColor: colors.subtle
+                    Accessible.name: "Webpage URL"
+                    Accessible.description: "Enter an http or https webpage URL to convert"
                     Layout.fillWidth: true
                     onAccepted: {
-                        app.addUrl(text)
-                        text = ""
+                        if (app.addUrl(text))
+                            text = ""
                     }
                 }
 
@@ -796,9 +879,10 @@ ApplicationWindow {
                     surfaceColor: colors.surfaceAlt
                     borderColor: colors.border
                     textColor: colors.text
+                    Accessible.name: "Add webpage URL"
                     onClicked: {
-                        app.addUrl(compactUrlInput.text)
-                        compactUrlInput.text = ""
+                        if (app.addUrl(compactUrlInput.text))
+                            compactUrlInput.text = ""
                     }
                 }
             }
@@ -1004,6 +1088,7 @@ ApplicationWindow {
                                     iconName: "trash-2"
                                     accentColor: colors.action
                                     textColor: colors.muted
+                                    Accessible.name: "Remove " + name + " from queue"
                                     onClicked: app.removeQueued(index)
                                 }
                             }
@@ -1101,7 +1186,7 @@ ApplicationWindow {
 
                         ThemeToggleRow {
                             title: "OCR"
-                            detail: "Provider: " + (app.ocrProvider === "glmocr" ? "GLM-OCR" : "Azure + Tesseract") + ". Use for scanned or image-heavy inputs."
+                            detail: "Provider: " + root.ocrProviderLabel(app.ocrProvider) + ". Use for scanned or image-heavy inputs."
                             enabled: !app.converting
                             checked: app.ocrEnabled
                             textColor: colors.text
@@ -1252,13 +1337,15 @@ ApplicationWindow {
                     }
 
                     AppButton {
-                        text: "Cancel"
+                        text: "Stop after current"
                         enabled: app.converting
                         iconName: "x"
                         accentColor: colors.action
                         surfaceColor: colors.surfaceAlt
                         borderColor: colors.border
                         textColor: colors.text
+                        Accessible.name: "Stop after the current conversion"
+                        Accessible.description: "The active file finishes before remaining queued items are cancelled."
                         onClicked: app.cancel()
                     }
                 }
@@ -1299,42 +1386,106 @@ ApplicationWindow {
                 Layout.preferredWidth: 300
                 Layout.fillHeight: true
 
-                RowLayout {
+                Rectangle {
+                    visible: app.converting
+                    implicitHeight: activeResultControls.implicitHeight + 20
+                    radius: 8
+                    color: colors.surfaceAlt
+                    border.color: colors.border
                     Layout.fillWidth: true
 
-                    AppButton {
-                        text: "Back to queue"
-                        subtle: true
-                        iconName: "rotate-ccw"
-                        accentColor: colors.action
-                        textColor: colors.text
-                        onClicked: app.clearResults()
-                    }
+                    ColumnLayout {
+                        id: activeResultControls
+                        anchors.fill: parent
+                        anchors.margins: 10
+                        spacing: 7
 
-                    AppButton {
-                        text: "Start new"
-                        subtle: true
-                        iconName: "file-text"
-                        accentColor: colors.action
-                        textColor: colors.muted
-                        onClicked: {
-                            app.clearResults()
-                            app.clearQueue()
+                        Label {
+                            text: app.statusText
+                            color: colors.muted
+                            font.pixelSize: 12
+                            elide: Text.ElideMiddle
+                            Layout.fillWidth: true
+                        }
+
+                        ThemeProgressBar {
+                            value: app.progress
+                            Layout.fillWidth: true
+                        }
+
+                        RowLayout {
+                            spacing: 8
+                            Layout.fillWidth: true
+
+                            AppButton {
+                                text: app.paused ? "Resume" : "Pause"
+                                iconName: app.paused ? "play" : "pause"
+                                accentColor: colors.action
+                                surfaceColor: colors.surface
+                                borderColor: colors.border
+                                textColor: colors.text
+                                Layout.fillWidth: true
+                                onClicked: app.togglePause()
+                            }
+
+                            AppButton {
+                                text: "Stop after current"
+                                iconName: "x"
+                                accentColor: colors.action
+                                surfaceColor: colors.surface
+                                borderColor: colors.border
+                                textColor: colors.text
+                                Accessible.name: "Stop after the current conversion"
+                                Accessible.description: "The active file finishes before remaining queued items are cancelled."
+                                Layout.fillWidth: true
+                                onClicked: app.cancel()
+                            }
+                        }
+                    }
+                }
+
+                ColumnLayout {
+                    Layout.fillWidth: true
+                    spacing: 6
+
+                    RowLayout {
+                        Layout.fillWidth: true
+
+                        AppButton {
+                            text: "Back to queue"
+                            enabled: !app.converting
+                            subtle: true
+                            iconName: "rotate-ccw"
+                            accentColor: colors.action
+                            textColor: colors.text
+                            onClicked: app.backToQueue()
+                        }
+
+                        AppButton {
+                            text: "Start new"
+                            enabled: !app.converting
+                            subtle: true
+                            iconName: "file-text"
+                            accentColor: colors.action
+                            textColor: colors.muted
+                            onClicked: app.startNew()
+                        }
+
+                        Item {
+                            Layout.fillWidth: true
                         }
                     }
 
                     AppButton {
                         visible: app.hasFailedResults
-                        text: "Retry"
+                        enabled: !app.converting
+                        text: "Retry failed conversions"
                         subtle: true
                         iconName: "rotate-ccw"
                         accentColor: colors.danger
                         textColor: colors.danger
-                        onClicked: app.retryFailedResults()
-                    }
-
-                    Item {
                         Layout.fillWidth: true
+                        onClicked: app.retryFailedResults()
                     }
                 }
 
@@ -1374,7 +1525,7 @@ ApplicationWindow {
                                 : colors.border
                         border.width: activeFocus ? 2 : 1
                         Accessible.role: Accessible.ListItem
-                        Accessible.name: name + (failed ? ", failed conversion" : ", converted") + ", " + wordCount + " words"
+                        Accessible.name: name + (failed ? ", failed conversion" : ", converted, " + wordCount + " words")
 
                         Behavior on color {
                             ColorAnimation {
@@ -1461,6 +1612,7 @@ ApplicationWindow {
                                     }
 
                                     Label {
+                                        visible: !failed
                                         text: wordCount + " words"
                                         color: colors.muted
                                         font.pixelSize: 11
@@ -1529,8 +1681,8 @@ ApplicationWindow {
                         AppButton {
                             visible: !previewToolbar.compactActions
                             text: app.saveCombined ? "Save as one file" : "Save files"
-                            enabled: app.hasSuccessfulResults && !app.selectedResultFailed
-                            primary: !app.selectedResultFailed
+                            enabled: app.hasSuccessfulResults
+                            primary: app.hasSuccessfulResults
                             iconName: "save"
                             accentColor: colors.action
                             primaryTextColor: colors.onAction
@@ -1562,8 +1714,8 @@ ApplicationWindow {
 
                         AppButton {
                             text: "Save"
-                            enabled: app.hasSuccessfulResults && !app.selectedResultFailed
-                            primary: !app.selectedResultFailed
+                            enabled: app.hasSuccessfulResults
+                            primary: app.hasSuccessfulResults
                             iconName: "save"
                             accentColor: colors.action
                             primaryTextColor: colors.onAction
@@ -1889,6 +2041,7 @@ ApplicationWindow {
                         AppTextField {
                             text: app.outputFolder
                             placeholderText: "No default folder set"
+                            Accessible.name: "Default output folder"
                             surfaceColor: colors.input
                             borderColor: colors.border
                             accentColor: colors.accent
@@ -1929,17 +2082,14 @@ ApplicationWindow {
                     Layout.fillWidth: true
                 }
 
-                SettingsField {
-                    label: "Batch size"
-                    detail: "Limit how many sources convert in one worker batch."
+                ThemeToggleRow {
+                    title: "Update notifications"
+                    detail: "Show a notification when a new release is available."
+                    checked: app.updateNotificationsEnabled
+                    textColor: colors.text
+                    mutedTextColor: colors.muted
+                    onToggled: checked => app.setUpdateNotificationsEnabled(checked)
                     Layout.fillWidth: true
-
-                    ThemeSpinBox {
-                        from: 1
-                        to: 10
-                        value: app.batchSize
-                        onValueModified: app.setBatchSize(value)
-                    }
                 }
             }
 
@@ -1962,6 +2112,7 @@ ApplicationWindow {
                     Layout.fillWidth: true
 
                     ThemeComboBox {
+                        Accessible.name: "Application theme"
                         model: ["Solarized Light", "Nord Dark", "System"]
                         currentIndex: app.themeMode === "dark" ? 1 : app.themeMode === "system" ? 2 : 0
                         onActivated: index => app.setThemeMode(index === 1 ? "dark" : index === 2 ? "system" : "light")
@@ -2054,6 +2205,7 @@ ApplicationWindow {
                     Layout.fillWidth: true
 
                     ThemeComboBox {
+                        Accessible.name: "Primary OCR provider"
                         model: ["Azure + Tesseract", "GLM-OCR", "HTTP OCR"]
                         currentIndex: root.ocrProviderIndex(app.ocrProvider)
                         onActivated: index => app.setOcrProvider(root.ocrProviderFromIndex(index))
@@ -2068,6 +2220,7 @@ ApplicationWindow {
                     Layout.fillWidth: true
 
                     ThemeComboBox {
+                        Accessible.name: "Fallback OCR provider"
                         model: root.ocrFallbackLabels()
                         currentIndex: root.ocrFallbackIndex(app.ocrFallbackProvider)
                         onActivated: index => app.setOcrFallbackProvider(root.ocrFallbackFromIndex(index))
@@ -2181,6 +2334,7 @@ ApplicationWindow {
                     AppTextField {
                         text: app.docintelEndpoint
                         placeholderText: "https://example.cognitiveservices.azure.com/"
+                        Accessible.name: app.ocrProvider === "glmocr" ? "Fallback Azure endpoint" : "Azure endpoint"
                         surfaceColor: colors.input
                         borderColor: colors.border
                         accentColor: colors.accent
@@ -2200,6 +2354,7 @@ ApplicationWindow {
                     AppTextField {
                         text: app.ocrLanguages
                         placeholderText: "eng or eng+deu"
+                        Accessible.name: app.ocrProvider === "glmocr" ? "Fallback Tesseract languages" : "Tesseract languages"
                         surfaceColor: colors.input
                         borderColor: colors.border
                         accentColor: colors.accent
@@ -2219,6 +2374,7 @@ ApplicationWindow {
                     AppTextField {
                         text: app.tesseractPath
                         placeholderText: "Optional executable path"
+                        Accessible.name: app.ocrProvider === "glmocr" ? "Fallback Tesseract executable" : "Tesseract executable"
                         surfaceColor: colors.input
                         borderColor: colors.border
                         accentColor: colors.accent
@@ -2254,7 +2410,7 @@ ApplicationWindow {
 
                     AppButton {
                         text: "Test connection"
-                        iconName: "server"
+                        iconName: "external-link"
                         accentColor: colors.action
                         surfaceColor: colors.surfaceAlt
                         borderColor: colors.border
@@ -2288,6 +2444,7 @@ ApplicationWindow {
                     Layout.fillWidth: true
 
                     ThemeComboBox {
+                        Accessible.name: "GLM-OCR mode"
                         model: ["Official API", "Ollama", "SDK Server"]
                         currentIndex: app.glmocrMode === "ollama" ? 1 : app.glmocrMode === "sdk_server" ? 2 : 0
                         onActivated: index => app.setGlmocrMode(index === 1 ? "ollama" : index === 2 ? "sdk_server" : "maas")
@@ -2303,6 +2460,7 @@ ApplicationWindow {
                     AppTextField {
                         text: app.glmocrOllamaHost
                         placeholderText: "127.0.0.1"
+                        Accessible.name: "GLM-OCR Ollama host"
                         surfaceColor: colors.input
                         borderColor: colors.border
                         accentColor: colors.accent
@@ -2324,6 +2482,7 @@ ApplicationWindow {
                         Layout.fillWidth: false
 
                         ThemeSpinBox {
+                            Accessible.name: "GLM-OCR Ollama port"
                             from: 1
                             to: 65535
                             value: app.glmocrOllamaPort
@@ -2339,6 +2498,7 @@ ApplicationWindow {
                         AppTextField {
                             text: app.glmocrOllamaModel
                             placeholderText: "glm-ocr:latest"
+                            Accessible.name: "GLM-OCR Ollama model"
                             surfaceColor: colors.input
                             borderColor: colors.border
                             accentColor: colors.accent
@@ -2358,6 +2518,7 @@ ApplicationWindow {
                     AppTextField {
                         text: app.glmocrSdkServerUrl
                         placeholderText: "http://127.0.0.1:5002/glmocr/parse"
+                        Accessible.name: "GLM-OCR SDK server endpoint"
                         surfaceColor: colors.input
                         borderColor: colors.border
                         accentColor: colors.accent
@@ -2391,6 +2552,7 @@ ApplicationWindow {
                     AppTextField {
                         text: app.httpOcrEndpoint
                         placeholderText: "http://127.0.0.1:8000/ocr"
+                        Accessible.name: "HTTP OCR endpoint"
                         surfaceColor: colors.input
                         borderColor: colors.border
                         accentColor: colors.accent
@@ -2413,6 +2575,7 @@ ApplicationWindow {
                         AppTextField {
                             text: app.httpOcrModel
                             placeholderText: "surya, doctr, paddleocr, ..."
+                            Accessible.name: "HTTP OCR model"
                             surfaceColor: colors.input
                             borderColor: colors.border
                             accentColor: colors.accent
@@ -2430,6 +2593,7 @@ ApplicationWindow {
                         Layout.fillWidth: false
 
                         ThemeSpinBox {
+                            Accessible.name: "HTTP OCR timeout in seconds"
                             from: 1
                             to: 3600
                             value: app.httpOcrTimeoutSeconds
@@ -2447,6 +2611,7 @@ ApplicationWindow {
                     AppTextField {
                         text: app.httpOcrApiKeyEnv
                         placeholderText: "OCR_HTTP_API_KEY"
+                        Accessible.name: "HTTP OCR API key environment variable"
                         surfaceColor: colors.input
                         borderColor: colors.border
                         accentColor: colors.accent
@@ -2495,7 +2660,7 @@ ApplicationWindow {
 
                     AppButton {
                         text: "Import"
-                        iconName: "upload"
+                        iconName: "folder-plus"
                         accentColor: colors.action
                         surfaceColor: colors.surfaceAlt
                         borderColor: colors.border

--- a/markitdowngui/qml/Main.qml
+++ b/markitdowngui/qml/Main.qml
@@ -2769,6 +2769,52 @@ ApplicationWindow {
             }
 
             UtilitySectionPanel {
+                title: "Licensing"
+                subtitle: "Terms for the app and bundled third-party components."
+
+                Label {
+                    text: "MarkItDown GUI is licensed under the MIT License. Commercial use, private use, modification, redistribution, sublicensing, and sale are permitted when the copyright and licence notice are preserved."
+                    color: colors.text
+                    font.pixelSize: 13
+                    wrapMode: Text.WordWrap
+                    Layout.fillWidth: true
+                }
+
+                Label {
+                    text: "Bundled dependencies keep their own terms. PySide6/Qt is used under Qt's LGPL/commercial licensing model, and packaged builds include third-party notices."
+                    color: colors.muted
+                    font.pixelSize: 12
+                    wrapMode: Text.WordWrap
+                    Layout.fillWidth: true
+                }
+
+                GridLayout {
+                    columns: helpPage.width < 640 ? 1 : 2
+                    columnSpacing: 10
+                    rowSpacing: 10
+                    Layout.fillWidth: true
+
+                    Repeater {
+                        model: [
+                            { label: "Project licence", url: "https://github.com/imadreamerboy/markitdown-gui/blob/main/LICENSE" },
+                            { label: "Third-party notices", url: "https://github.com/imadreamerboy/markitdown-gui/blob/main/THIRD_PARTY_NOTICES.md" }
+                        ]
+
+                        delegate: AppButton {
+                            text: modelData.label
+                            iconName: "external-link"
+                            accentColor: colors.action
+                            surfaceColor: colors.surfaceAlt
+                            borderColor: colors.border
+                            textColor: colors.text
+                            Layout.fillWidth: true
+                            onClicked: app.openExternalUrl(modelData.url)
+                        }
+                    }
+                }
+            }
+
+            UtilitySectionPanel {
                 title: "Diagnostics"
                 subtitle: "Useful when an update, OCR provider, or conversion fails."
 

--- a/markitdowngui/qml/components/SideNav.qml
+++ b/markitdowngui/qml/components/SideNav.qml
@@ -75,6 +75,8 @@ Item {
             Layout.fillWidth: true
             implicitHeight: 56
             flat: true
+            Accessible.name: "Workspace"
+            Accessible.description: "Convert documents and webpages"
             onClicked: root.pageRequested(0)
             ToolTip.visible: hovered
             ToolTip.delay: 550
@@ -171,6 +173,8 @@ Item {
                 Layout.fillWidth: true
                 implicitHeight: 40
                 flat: true
+                Accessible.name: "Help"
+                Accessible.description: "Open help and keyboard shortcuts"
                 onClicked: root.pageRequested(2)
                 ToolTip.visible: hovered
                 ToolTip.delay: 550
@@ -231,6 +235,8 @@ Item {
                 Layout.fillWidth: true
                 implicitHeight: 40
                 flat: true
+                Accessible.name: "Settings"
+                Accessible.description: "Configure output, appearance, and OCR"
                 onClicked: root.pageRequested(1)
                 ToolTip.visible: hovered
                 ToolTip.delay: 550

--- a/markitdowngui/ui_qml/controller.py
+++ b/markitdowngui/ui_qml/controller.py
@@ -1185,11 +1185,15 @@ class AppController(QObject):
 
     @Slot(bool)
     def setUpdateNotificationsEnabled(self, enabled: bool) -> None:
-        self.settings.set_update_notifications_enabled(bool(enabled))
+        enabled = bool(enabled)
+        self.settings.set_update_notifications_enabled(enabled)
         self.settingsChanged.emit()
         self.diagnosticsChanged.emit()
-        self.dismissUpdateNotification()
-        self.toastRequested.emit("success", "Update notifications disabled.")
+        if not enabled:
+            self.dismissUpdateNotification()
+            self.toastRequested.emit("success", "Update notifications disabled.")
+        else:
+            self.updateNotificationChanged.emit()
 
     @Slot()
     def openReleases(self) -> None:
@@ -1227,11 +1231,14 @@ class AppController(QObject):
                 self.toastRequested.emit("error", reason)
             self.openReleaseAsset(str(self._preferred_release_asset.get("url") or ""))
             return
-        if self._request_result_discard(
-            "install the update and close the application",
-            lambda: self._discard_results_and_continue(
-                self._start_preferred_update_install
-            ),
+        if (
+            self._preferred_release_asset.get("installMode") == "zip"
+            and self._request_result_discard(
+                "install the update and close the application",
+                lambda: self._discard_results_and_continue(
+                    self._start_preferred_update_install
+                ),
+            )
         ):
             return
         self._start_preferred_update_install()

--- a/markitdowngui/ui_qml/controller.py
+++ b/markitdowngui/ui_qml/controller.py
@@ -164,6 +164,7 @@ class AppController(QObject):
     diagnosticsChanged = Signal()
     discardResultsRequested = Signal(str)
     closeApproved = Signal()
+    urlQueued = Signal(str)
     toastRequested = Signal(str, str)
 
     def __init__(self) -> None:
@@ -558,26 +559,32 @@ class AppController(QObject):
     def sourceUpdateStatus(self) -> str:
         return self._source_update_status
 
-    @Slot("QVariant")
-    def addFiles(self, values: Any) -> None:
+    @Slot("QVariant", result=bool)
+    def addFiles(self, values: Any) -> bool:
         if self._queue_change_locked():
-            return
+            return False
         sources = [path for path in self._paths_from_variant(values) if path]
         if not self._has_new_queue_sources(sources):
-            return
+            return False
         if self._request_result_discard(
             "add inputs to the queue",
             lambda: self._add_files_to_queue(sources),
         ):
-            return
-        self._add_files_to_queue(sources)
+            return False
+        return self._add_files_to_queue(sources)
 
-    def _add_files_to_queue(self, sources: list[str]) -> None:
+    def _add_files_to_queue(self, sources: list[str]) -> bool:
+        existing_sources = set(self.queue_model.sources())
         added = self.queue_model.add_sources(sources)
-        if added:
-            self._clear_results_after_queue_change()
-            self._set_status(f"Added {added} input{'s' if added != 1 else ''}")
-            self.queueChanged.emit()
+        if not added:
+            return False
+        self._clear_results_after_queue_change()
+        self._set_status(f"Added {added} input{'s' if added != 1 else ''}")
+        self.queueChanged.emit()
+        for source in sources:
+            if source not in existing_sources and is_web_url(source):
+                self.urlQueued.emit(source)
+        return True
 
     @Slot(str, result=bool)
     def addUrl(self, value: str) -> bool:
@@ -585,8 +592,7 @@ class AppController(QObject):
         if not is_web_url(url):
             self.toastRequested.emit("error", "Enter a valid http:// or https:// URL.")
             return False
-        self.addFiles([url])
-        return True
+        return self.addFiles([url])
 
     @Slot(int)
     def removeQueued(self, row: int) -> None:
@@ -865,6 +871,7 @@ class AppController(QObject):
             Path(fallback_dir).mkdir(parents=True, exist_ok=True)
 
         saved_paths: list[str] = []
+        failed_paths: list[str] = []
         saved_sources: set[str] = set()
         for item in items:
             output_dir = self._separate_output_dir(fallback_dir, item.source)
@@ -884,8 +891,18 @@ class AppController(QObject):
                 saved_sources.add(item.source)
             except Exception as exc:
                 AppLogger.error(f"Failed saving {output_path}: {exc}")
+                failed_paths.append(output_path)
 
-        if saved_paths:
+        if saved_paths and failed_paths:
+            self._mark_results_saved(saved_sources)
+            saved_label = "file" if len(saved_paths) == 1 else "files"
+            failed_label = "file" if len(failed_paths) == 1 else "files"
+            self.toastRequested.emit(
+                "error",
+                f"Saved {len(saved_paths)} {saved_label}; "
+                f"{len(failed_paths)} {failed_label} failed to save.",
+            )
+        elif saved_paths:
             self._mark_results_saved(saved_sources)
             self.toastRequested.emit("success", f"Saved {len(saved_paths)} files.")
         else:
@@ -2226,4 +2243,3 @@ class AppController(QObject):
     def translate(self, key: str) -> str:
         lang = self.settings.get_current_language() or DEFAULT_LANG
         return get_translation(lang, key)
-

--- a/markitdowngui/ui_qml/controller.py
+++ b/markitdowngui/ui_qml/controller.py
@@ -683,7 +683,7 @@ class AppController(QObject):
         if not failed_sources:
             self.toastRequested.emit("error", "No failed conversions to retry.")
             return
-        if not self._preflight_conversion():
+        if not self._preflight_conversion(failed_sources):
             return
         self._retry_failed_results(failed_sources)
 
@@ -1227,6 +1227,16 @@ class AppController(QObject):
                 self.toastRequested.emit("error", reason)
             self.openReleaseAsset(str(self._preferred_release_asset.get("url") or ""))
             return
+        if self._request_result_discard(
+            "install the update and close the application",
+            lambda: self._discard_results_and_continue(
+                self._start_preferred_update_install
+            ),
+        ):
+            return
+        self._start_preferred_update_install()
+
+    def _start_preferred_update_install(self) -> None:
         self._update_install_running = True
         self._update_install_progress = 0
         self._update_install_status = "Preparing update"
@@ -2056,11 +2066,11 @@ class AppController(QObject):
         self._clear_results()
         self.closeApproved.emit()
 
-    def _preflight_conversion(self) -> bool:
+    def _preflight_conversion(self, sources: list[str] | None = None) -> bool:
         preflight_options = self._build_conversion_options(create_asset_root=False)
         if (
             not preflight_options.ocr_enabled
-            or not self._queue_has_ocr_input()
+            or not self._queue_has_ocr_input(sources)
         ):
             return True
         preflight = validate_ocr_setup(preflight_options)
@@ -2070,11 +2080,13 @@ class AppController(QObject):
         self.toastRequested.emit("error", preflight.message)
         return False
 
-    def _queue_has_ocr_input(self) -> bool:
+    def _queue_has_ocr_input(self, sources: list[str] | None = None) -> bool:
         return any(
             not is_web_url(source)
             and Path(source).suffix.lower() in (IMAGE_EXTENSIONS | {PDF_EXTENSION})
-            for source in self.queue_model.sources()
+            for source in (
+                self.queue_model.sources() if sources is None else sources
+            )
         )
 
     def _mark_results_saved(self, sources: set[str]) -> None:

--- a/markitdowngui/ui_qml/controller.py
+++ b/markitdowngui/ui_qml/controller.py
@@ -5,7 +5,7 @@ import re
 import sys
 import tempfile
 from pathlib import Path
-from typing import Any
+from typing import Any, Callable
 
 from PySide6.QtCore import QObject, Property, QProcess, QThread, QUrl, Signal, Slot
 from PySide6.QtGui import QDesktopServices, QGuiApplication, QPalette, QTextDocument
@@ -26,6 +26,7 @@ from markitdowngui.core.conversion import (
     OCR_PROVIDER_HTTP,
     OCR_PROVIDER_NONE,
     ZHIPU_API_KEY_ENV_VAR,
+    ConversionOutcome,
     ConversionOptions,
     ConversionWorker,
     get_ocr_provider_specs,
@@ -40,10 +41,11 @@ from markitdowngui.core.input_sources import (
 )
 from markitdowngui.core.markdown_assets import (
     MarkdownSaveInput,
+    PreparedMarkdownAssets,
     cleanup_temp_asset_root,
     create_temp_asset_root,
-    prepare_combined_markdown_for_save,
-    prepare_markdown_for_separate_save,
+    prepare_combined_markdown_for_save_transaction,
+    prepare_markdown_for_separate_save_transaction,
     rewrite_markdown_for_preview,
 )
 from markitdowngui.core.settings import SettingsManager
@@ -160,6 +162,8 @@ class AppController(QObject):
     updateInstallChanged = Signal()
     sourceUpdateChanged = Signal()
     diagnosticsChanged = Signal()
+    discardResultsRequested = Signal(str)
+    closeApproved = Signal()
     toastRequested = Signal(str, str)
 
     def __init__(self) -> None:
@@ -176,7 +180,12 @@ class AppController(QObject):
         self._selected_result_index = -1
         self._preview_mode = "rendered"
         self._temp_asset_root: str | None = None
+        # Failed-only retries retain successful outputs, so their asset roots must
+        # outlive the next conversion worker until the result set is cleared.
+        self._temp_asset_roots: set[str] = set()
         self._cancel_requested = False
+        self._unsaved_result_sources: set[str] = set()
+        self._pending_result_discard: Callable[[], None] | None = None
         self._update_checker: UpdateChecker | None = None
         self._update_installer: PackagedUpdateInstaller | None = None
         self._update_check_manual = False
@@ -233,6 +242,13 @@ class AppController(QObject):
     @Property(bool, notify=resultsChanged)
     def hasSuccessfulResults(self) -> bool:
         return bool(self._successful_result_items())
+
+    @Property(bool, notify=resultsChanged)
+    def hasUnsavedSuccessfulResults(self) -> bool:
+        successful_sources = {
+            item.source for item in self._successful_result_items()
+        }
+        return bool(self._unsaved_result_sources & successful_sources)
 
     @Property(bool, notify=resultsChanged)
     def hasFailedResults(self) -> bool:
@@ -327,6 +343,10 @@ class AppController(QObject):
     @Property(bool, notify=settingsChanged)
     def saveToSourceFolder(self) -> bool:
         return self.settings.get_save_to_source_folder()
+
+    @Property(bool, notify=settingsChanged)
+    def updateNotificationsEnabled(self) -> bool:
+        return self.settings.get_update_notifications_enabled()
 
     @Property(int, notify=settingsChanged)
     def batchSize(self) -> int:
@@ -543,24 +563,45 @@ class AppController(QObject):
         if self._queue_change_locked():
             return
         sources = [path for path in self._paths_from_variant(values) if path]
+        if not self._has_new_queue_sources(sources):
+            return
+        if self._request_result_discard(
+            "add inputs to the queue",
+            lambda: self._add_files_to_queue(sources),
+        ):
+            return
+        self._add_files_to_queue(sources)
+
+    def _add_files_to_queue(self, sources: list[str]) -> None:
         added = self.queue_model.add_sources(sources)
         if added:
             self._clear_results_after_queue_change()
             self._set_status(f"Added {added} input{'s' if added != 1 else ''}")
             self.queueChanged.emit()
 
-    @Slot(str)
-    def addUrl(self, value: str) -> None:
+    @Slot(str, result=bool)
+    def addUrl(self, value: str) -> bool:
         url = value.strip()
         if not is_web_url(url):
             self.toastRequested.emit("error", "Enter a valid http:// or https:// URL.")
-            return
+            return False
         self.addFiles([url])
+        return True
 
     @Slot(int)
     def removeQueued(self, row: int) -> None:
         if self._queue_change_locked():
             return
+        if not 0 <= row < self.queue_model.rowCount():
+            return
+        if self._request_result_discard(
+            "change the queue",
+            lambda: self._remove_queued(row),
+        ):
+            return
+        self._remove_queued(row)
+
+    def _remove_queued(self, row: int) -> None:
         sources_before = self.queue_model.sources()
         self.queue_model.remove(row)
         if self.queue_model.sources() != sources_before:
@@ -571,6 +612,11 @@ class AppController(QObject):
     def clearQueue(self) -> None:
         if self._queue_change_locked():
             return
+        if self._request_result_discard("clear the queue", self._clear_queue):
+            return
+        self._clear_queue()
+
+    def _clear_queue(self) -> None:
         self.queue_model.clear()
         self._clear_results_after_queue_change()
         self.queueChanged.emit()
@@ -578,7 +624,41 @@ class AppController(QObject):
 
     @Slot()
     def clearResults(self) -> None:
+        self.backToQueue()
+
+    @Slot()
+    def backToQueue(self) -> None:
+        if self._queue_change_locked():
+            return
+        if self._request_result_discard("return to the queue", self._clear_results):
+            return
+        self._clear_results()
+
+    @Slot()
+    def startNew(self) -> None:
+        if self._queue_change_locked():
+            return
+        if self._request_result_discard("start a new conversion", self._start_new):
+            return
+        self._start_new()
+
+    def _start_new(self) -> None:
+        self._clear_queue()
+
+    @Slot()
+    def discardPendingResults(self) -> None:
+        action = self._pending_result_discard
+        self._pending_result_discard = None
+        if action is not None:
+            action()
+
+    @Slot()
+    def cancelPendingResultDiscard(self) -> None:
+        self._pending_result_discard = None
+
+    def _clear_results(self) -> None:
         self.result_model.clear()
+        self._unsaved_result_sources.clear()
         self._selected_result_index = -1
         self._progress = 0
         self._cleanup_temp_assets()
@@ -595,18 +675,31 @@ class AppController(QObject):
         if not failed_sources:
             self.toastRequested.emit("error", "No failed conversions to retry.")
             return
+        if not self._preflight_conversion():
+            return
+        self._retry_failed_results(failed_sources)
 
+    def _retry_failed_results(self, failed_sources: list[str]) -> None:
+        selected_item = self.result_model.item_at(self._selected_result_index)
+        selected_source = selected_item.source if selected_item else ""
         self.queue_model.clear()
         added = self.queue_model.add_sources(failed_sources)
-        self.clearResults()
-        self.queueChanged.emit()
-        self._set_status(
-            f"Queued {added} failed input{'s' if added != 1 else ''} for retry"
+        self.result_model.remove_sources(set(failed_sources))
+        remaining_sources = [item.source for item in self.result_model.items()]
+        self._selected_result_index = (
+            remaining_sources.index(selected_source)
+            if selected_source in remaining_sources
+            else 0 if remaining_sources else -1
         )
+        self.queueChanged.emit()
+        self.resultsChanged.emit()
+        self.selectedResultChanged.emit()
+        self.saveDefaultsChanged.emit()
         self.toastRequested.emit(
             "success",
-            f"Queued {added} failed input{'s' if added != 1 else ''} for retry.",
+            f"Retrying {added} failed input{'s' if added != 1 else ''}.",
         )
+        self._start_conversion(preserve_results=True, preflight_validated=True)
 
     @Slot()
     def convert(self) -> None:
@@ -617,7 +710,25 @@ class AppController(QObject):
             self.toastRequested.emit("error", "Add files or a website URL first.")
             return
 
-        self.clearResults()
+        if self._request_result_discard("start a new conversion", self._start_conversion):
+            return
+        self._start_conversion()
+
+    def _start_conversion(
+        self,
+        *,
+        preserve_results: bool = False,
+        preflight_validated: bool = False,
+    ) -> None:
+        sources = self.queue_model.sources()
+        if not sources:
+            return
+
+        if not preflight_validated and not self._preflight_conversion():
+            return
+
+        if not preserve_results:
+            self._clear_results()
         self._cancel_requested = False
         self.worker = ConversionWorker(
             files=sources,
@@ -625,6 +736,7 @@ class AppController(QObject):
             options=self._build_conversion_options(),
         )
         self.worker.progress.connect(self._handle_progress)
+        self.worker.itemFinished.connect(self._handle_item_finished)
         self.worker.finished.connect(self._handle_finished)
         self.worker.error.connect(lambda message: self.toastRequested.emit("error", message))
         self.worker.start()
@@ -715,18 +827,19 @@ class AppController(QObject):
             for item in items
         ]
         try:
-            output = prepare_combined_markdown_for_save(
+            prepared_output = prepare_combined_markdown_for_save_transaction(
                 documents,
                 output_path,
                 source_heading_template="## {source}",
             )
-            self.file_manager.save_markdown_file(output_path, output)
+            self._save_prepared_markdown(output_path, prepared_output)
             self.settings.set_recent_outputs(
                 self.file_manager.update_recent_list(
                     output_path,
                     self.settings.get_recent_outputs(),
                 )
             )
+            self._mark_results_saved({item.source for item in items})
             self.toastRequested.emit("success", f"Saved {Path(output_path).name}.")
         except Exception as exc:
             AppLogger.error(f"Failed saving combined output: {exc}")
@@ -752,6 +865,7 @@ class AppController(QObject):
             Path(fallback_dir).mkdir(parents=True, exist_ok=True)
 
         saved_paths: list[str] = []
+        saved_sources: set[str] = set()
         for item in items:
             output_dir = self._separate_output_dir(fallback_dir, item.source)
             if not output_dir:
@@ -760,17 +874,19 @@ class AppController(QObject):
             Path(output_dir).mkdir(parents=True, exist_ok=True)
             output_path = self._unique_output_path(output_dir, item.source)
             try:
-                markdown = prepare_markdown_for_separate_save(
+                prepared_output = prepare_markdown_for_separate_save_transaction(
                     item.outcome.markdown,
                     item.outcome.assets,
                     output_path,
                 )
-                self.file_manager.save_markdown_file(output_path, markdown)
+                self._save_prepared_markdown(output_path, prepared_output)
                 saved_paths.append(output_path)
+                saved_sources.add(item.source)
             except Exception as exc:
                 AppLogger.error(f"Failed saving {output_path}: {exc}")
 
         if saved_paths:
+            self._mark_results_saved(saved_sources)
             self.toastRequested.emit("success", f"Saved {len(saved_paths)} files.")
         else:
             self.toastRequested.emit("error", "No files were saved.")
@@ -1046,7 +1162,11 @@ class AppController(QObject):
 
     @Slot()
     def disableUpdateNotifications(self) -> None:
-        self.settings.set_update_notifications_enabled(False)
+        self.setUpdateNotificationsEnabled(False)
+
+    @Slot(bool)
+    def setUpdateNotificationsEnabled(self, enabled: bool) -> None:
+        self.settings.set_update_notifications_enabled(bool(enabled))
         self.settingsChanged.emit()
         self.diagnosticsChanged.emit()
         self.dismissUpdateNotification()
@@ -1740,13 +1860,17 @@ class AppController(QObject):
     def _clear_update_checker(self) -> None:
         self._update_checker = None
 
-    def _build_conversion_options(self) -> ConversionOptions:
+    def _build_conversion_options(
+        self,
+        *,
+        create_asset_root: bool = True,
+    ) -> ConversionOptions:
         artifacts_dir = ""
         preserve_pdf_images = self.settings.get_preserve_pdf_images()
         preserve_docx_images = self.settings.get_preserve_docx_images()
-        if preserve_pdf_images or preserve_docx_images:
-            self._cleanup_temp_assets()
+        if create_asset_root and (preserve_pdf_images or preserve_docx_images):
             self._temp_asset_root = str(create_temp_asset_root())
+            self._temp_asset_roots.add(self._temp_asset_root)
             artifacts_dir = self._temp_asset_root
 
         return ConversionOptions(
@@ -1777,12 +1901,33 @@ class AppController(QObject):
         self._set_status(f"Converting {Path(current_source).name or current_source}")
         self.progressChanged.emit()
 
+    def _handle_item_finished(
+        self,
+        source: str,
+        outcome: ConversionOutcome,
+        failed: bool,
+    ) -> None:
+        self.result_model.add_result(source, outcome, failed=failed)
+        if not failed:
+            self._unsaved_result_sources.add(source)
+        if self._selected_result_index < 0:
+            self._selected_result_index = 0
+        self.resultsChanged.emit()
+        self.selectedResultChanged.emit()
+        self.saveDefaultsChanged.emit()
+
     def _handle_finished(self, results: dict) -> None:
         worker = self.worker
         was_cancelled = self._cancel_requested or bool(worker and worker.is_cancelled)
         failed = set(worker.failed_files) if worker else set()
-        self.result_model.set_results(results, failed)
-        self._selected_result_index = 0 if results else -1
+        completed_sources = {item.source for item in self.result_model.items()}
+        for source, outcome in results.items():
+            item_failed = source in failed
+            self.result_model.add_result(source, outcome, failed=item_failed)
+            if not item_failed and source not in completed_sources:
+                self._unsaved_result_sources.add(source)
+        if self._selected_result_index < 0:
+            self._selected_result_index = 0 if results else -1
         self._converting = False
         self._paused = False
         self._progress = self._progress if was_cancelled else 100 if results else 0
@@ -1841,10 +1986,87 @@ class AppController(QObject):
     def _clear_results_after_queue_change(self) -> None:
         if self.result_model.rowCount() == 0:
             return
-        self.clearResults()
+        self._clear_results()
+
+    def _has_new_queue_sources(self, sources: list[str]) -> bool:
+        existing = set(self.queue_model.sources())
+        return any(source not in existing for source in sources)
+
+    def _request_result_discard(
+        self,
+        action_description: str,
+        action: Callable[[], None],
+    ) -> bool:
+        if not self.hasUnsavedSuccessfulResults:
+            return False
+        if self._pending_result_discard is None:
+            self._pending_result_discard = action
+            self.discardResultsRequested.emit(action_description)
+        return True
+
+    @Slot(result=bool)
+    def requestShutdown(self) -> bool:
+        if self._request_result_discard(
+            "close the application",
+            self._discard_results_and_close,
+        ):
+            return False
+        return self.shutdown()
+
+    def _discard_results_and_close(self) -> None:
+        if not self.shutdown():
+            return
+        self._clear_results()
+        self.closeApproved.emit()
+
+    def _preflight_conversion(self) -> bool:
+        preflight_options = self._build_conversion_options(create_asset_root=False)
+        if not preflight_options.ocr_enabled:
+            return True
+        preflight = validate_ocr_setup(preflight_options)
+        if preflight.ok:
+            return True
+        self._set_status("OCR setup needs attention")
+        self.toastRequested.emit("error", preflight.message)
+        return False
+
+    def _mark_results_saved(self, sources: set[str]) -> None:
+        if not self._unsaved_result_sources.intersection(sources):
+            return
+        self._unsaved_result_sources.difference_update(sources)
+        if not self.hasUnsavedSuccessfulResults:
+            self._pending_result_discard = None
+        self.resultsChanged.emit()
+
+    def _save_prepared_markdown(
+        self,
+        output_path: str,
+        prepared_output: PreparedMarkdownAssets,
+    ) -> None:
+        staged_markdown = None
+        try:
+            staged_markdown = self.file_manager.stage_markdown_file(
+                output_path,
+                prepared_output.markdown,
+            )
+            prepared_output.commit_assets()
+            staged_markdown.commit()
+        except Exception:
+            prepared_output.rollback_assets()
+            raise
+        else:
+            prepared_output.finalize_assets()
+        finally:
+            if staged_markdown is not None:
+                staged_markdown.abort()
 
     def _cleanup_temp_assets(self) -> None:
-        cleanup_temp_asset_root(self._temp_asset_root)
+        asset_roots = set(self._temp_asset_roots)
+        if self._temp_asset_root:
+            asset_roots.add(self._temp_asset_root)
+        for asset_root in asset_roots:
+            cleanup_temp_asset_root(asset_root)
+        self._temp_asset_roots.clear()
         self._temp_asset_root = None
 
     def _paths_from_variant(self, values: Any) -> list[str]:

--- a/markitdowngui/ui_qml/controller.py
+++ b/markitdowngui/ui_qml/controller.py
@@ -21,10 +21,12 @@ from markitdowngui.core.conversion import (
     GLMOCR_API_KEY_ENV_VAR,
     GLMOCR_MODE_OLLAMA,
     GLMOCR_MODE_SDK_SERVER,
+    IMAGE_EXTENSIONS,
     OCR_PROVIDER_AZURE_TESSERACT,
     OCR_PROVIDER_GLMOCR,
     OCR_PROVIDER_HTTP,
     OCR_PROVIDER_NONE,
+    PDF_EXTENSION,
     ZHIPU_API_KEY_ENV_VAR,
     ConversionOutcome,
     ConversionOptions,
@@ -1311,6 +1313,14 @@ class AppController(QObject):
                 "Wait for the current update to finish before restarting.",
             )
             return
+        if self._request_result_discard(
+            "restart the application",
+            lambda: self._discard_results_and_continue(self._restart_app),
+        ):
+            return
+        self._restart_app()
+
+    def _restart_app(self) -> None:
         if not self._start_restart_process():
             self.toastRequested.emit("error", "Could not restart the app.")
             return
@@ -1473,6 +1483,16 @@ class AppController(QObject):
         self.updateNotificationChanged.emit()
         self.sourceUpdateChanged.emit()
         self.diagnosticsChanged.emit()
+        if self._request_result_discard(
+            "close the application and install the update",
+            lambda: self._discard_results_and_continue(
+                self._quit_for_packaged_update
+            ),
+        ):
+            return
+        self._quit_for_packaged_update()
+
+    def _quit_for_packaged_update(self) -> None:
         self.toastRequested.emit("success", "Update installer started. Closing app.")
         self.dismissUpdateNotification()
         QGuiApplication.quit()
@@ -2038,7 +2058,10 @@ class AppController(QObject):
 
     def _preflight_conversion(self) -> bool:
         preflight_options = self._build_conversion_options(create_asset_root=False)
-        if not preflight_options.ocr_enabled:
+        if (
+            not preflight_options.ocr_enabled
+            or not self._queue_has_ocr_input()
+        ):
             return True
         preflight = validate_ocr_setup(preflight_options)
         if preflight.ok:
@@ -2047,6 +2070,13 @@ class AppController(QObject):
         self.toastRequested.emit("error", preflight.message)
         return False
 
+    def _queue_has_ocr_input(self) -> bool:
+        return any(
+            not is_web_url(source)
+            and Path(source).suffix.lower() in (IMAGE_EXTENSIONS | {PDF_EXTENSION})
+            for source in self.queue_model.sources()
+        )
+
     def _mark_results_saved(self, sources: set[str]) -> None:
         if not self._unsaved_result_sources.intersection(sources):
             return
@@ -2054,6 +2084,10 @@ class AppController(QObject):
         if not self.hasUnsavedSuccessfulResults:
             self._pending_result_discard = None
         self.resultsChanged.emit()
+
+    def _discard_results_and_continue(self, action: Callable[[], None]) -> None:
+        self._clear_results()
+        action()
 
     def _save_prepared_markdown(
         self,

--- a/markitdowngui/ui_qml/models.py
+++ b/markitdowngui/ui_qml/models.py
@@ -174,6 +174,39 @@ class ResultModel(QAbstractListModel):
         ]
         self.endResetModel()
 
+    def add_result(
+        self,
+        source: str,
+        outcome: ConversionOutcome,
+        *,
+        failed: bool = False,
+    ) -> None:
+        """Append or replace one completed conversion without resetting the model."""
+        item = ResultItem(source, outcome, failed)
+        for row, existing in enumerate(self._items):
+            if existing.source != source:
+                continue
+            self._items[row] = item
+            model_index = self.index(row, 0)
+            self.dataChanged.emit(model_index, model_index)
+            return
+
+        row = len(self._items)
+        self.beginInsertRows(QModelIndex(), row, row)
+        self._items.append(item)
+        self.endInsertRows()
+
+    def remove_sources(self, sources: set[str]) -> None:
+        """Remove completed entries that are about to be retried."""
+        if not sources:
+            return
+        remaining = [item for item in self._items if item.source not in sources]
+        if len(remaining) == len(self._items):
+            return
+        self.beginResetModel()
+        self._items = remaining
+        self.endResetModel()
+
     def clear(self) -> None:
         if not self._items:
             return

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=61.0"]
+requires = ["setuptools>=77.0"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -7,7 +7,8 @@ name = "markitdowngui"
 version = "0.1.0"
 description = "A GUI wrapper for MarkItDown to convert files to Markdown via drag-and-drop."
 authors = [{name = "imadreamerboy", email = "jonas@imadreamerboy.com"}]
-license = { file = "LICENSE" }
+license = "MIT"
+license-files = ["LICENSE", "THIRD_PARTY_NOTICES.md"]
 readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [

--- a/tests/core/test_conversion.py
+++ b/tests/core/test_conversion.py
@@ -1532,7 +1532,7 @@ def test_conversion_worker_tracks_failed_files_separately_from_result_text(
     monkeypatch,
     conversion,
 ):
-    def fake_convert_with_details(file_path, _options):
+    def fake_convert_with_details(file_path, _options, **_kwargs):
         if file_path == "failure.pdf":
             raise RuntimeError("azure unavailable")
         return conversion.ConversionOutcome(
@@ -1552,7 +1552,7 @@ def test_conversion_worker_tracks_failed_files_separately_from_result_text(
 
 
 def test_conversion_worker_tracks_processing_backends(monkeypatch, conversion):
-    def fake_convert_with_details(file_path, _options):
+    def fake_convert_with_details(file_path, _options, **_kwargs):
         backend = (
             conversion.BACKEND_AZURE
             if file_path.endswith(".pdf")
@@ -1584,6 +1584,47 @@ def test_conversion_worker_emits_finished_when_cancelled_while_paused(conversion
     worker.run()
 
     assert finished == [{}]
+
+
+def test_conversion_worker_reuses_markitdown_instance_for_native_files(
+    monkeypatch,
+    conversion,
+):
+    constructions: list[dict[str, object]] = []
+    converted: list[str] = []
+
+    class FakeMarkItDown:
+        def __init__(self, **kwargs):
+            constructions.append(kwargs)
+
+        def convert(self, file_path):
+            converted.append(file_path)
+            return types.SimpleNamespace(text_content=f"# {file_path}")
+
+    monkeypatch.setitem(
+        sys.modules,
+        "markitdown",
+        types.SimpleNamespace(MarkItDown=FakeMarkItDown),
+    )
+
+    worker = conversion.ConversionWorker(
+        ["first.txt", "second.txt", "third.txt"],
+        batch_size=10,
+    )
+    completed: list[tuple[str, bool]] = []
+    worker.itemFinished.connect(
+        lambda source, _outcome, failed: completed.append((source, failed))
+    )
+
+    worker.run()
+
+    assert constructions == [{}]
+    assert converted == ["first.txt", "second.txt", "third.txt"]
+    assert completed == [
+        ("first.txt", False),
+        ("second.txt", False),
+        ("third.txt", False),
+    ]
 
 
 def test_run_tesseract_ocr_resets_executable_path_when_custom_path_is_cleared(

--- a/tests/core/test_file_utils.py
+++ b/tests/core/test_file_utils.py
@@ -1,5 +1,7 @@
 import os
+import stat
 import pytest
+from markitdowngui.core import file_utils
 from markitdowngui.core.file_utils import FileManager
 
 @pytest.fixture
@@ -83,3 +85,42 @@ def test_save_markdown_file_replaces_existing_content_without_temp_files(
 
     assert output_path.read_text(encoding="utf-8") == "new output"
     assert list(output_path.parent.glob(".report.md.*.tmp")) == []
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX permissions are not portable to Windows")
+def test_save_markdown_file_preserves_existing_permissions(file_manager, tmp_path):
+    output_path = tmp_path / "report.md"
+    output_path.write_text("old output", encoding="utf-8")
+    output_path.chmod(0o640)
+
+    file_manager.save_markdown_file(str(output_path), "new output")
+
+    assert stat.S_IMODE(output_path.stat().st_mode) == 0o640
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX permissions are not portable to Windows")
+def test_stage_markdown_file_closes_descriptor_when_permission_setup_fails(
+    file_manager,
+    tmp_path,
+    monkeypatch,
+):
+    output_path = tmp_path / "report.md"
+    output_path.write_text("old output", encoding="utf-8")
+    closed_descriptors: list[int] = []
+    original_close = os.close
+
+    def fail_fchmod(_descriptor, _mode):
+        raise OSError("permission setup failed")
+
+    def track_close(descriptor):
+        closed_descriptors.append(descriptor)
+        original_close(descriptor)
+
+    monkeypatch.setattr(file_utils.os, "fchmod", fail_fchmod)
+    monkeypatch.setattr(file_utils.os, "close", track_close)
+
+    with pytest.raises(OSError, match="permission setup failed"):
+        file_manager.stage_markdown_file(str(output_path), "new output")
+
+    assert len(closed_descriptors) == 1
+    assert list(tmp_path.glob(".report.md.*.tmp")) == []

--- a/tests/core/test_file_utils.py
+++ b/tests/core/test_file_utils.py
@@ -68,4 +68,18 @@ def test_save_and_get_backup_dir(file_manager):
     
     assert os.path.exists(backup_path)
     with open(backup_path, "r", encoding="utf-8") as f:
-        assert f.read() == content 
+        assert f.read() == content
+
+
+def test_save_markdown_file_replaces_existing_content_without_temp_files(
+    file_manager,
+    tmp_path,
+):
+    output_path = tmp_path / "nested" / "report.md"
+    output_path.parent.mkdir()
+    output_path.write_text("old output", encoding="utf-8")
+
+    file_manager.save_markdown_file(str(output_path), "new output")
+
+    assert output_path.read_text(encoding="utf-8") == "new output"
+    assert list(output_path.parent.glob(".report.md.*.tmp")) == []

--- a/tests/core/test_file_utils.py
+++ b/tests/core/test_file_utils.py
@@ -84,7 +84,35 @@ def test_save_markdown_file_replaces_existing_content_without_temp_files(
     file_manager.save_markdown_file(str(output_path), "new output")
 
     assert output_path.read_text(encoding="utf-8") == "new output"
-    assert list(output_path.parent.glob(".report.md.*.tmp")) == []
+    assert list(output_path.parent.glob(".markitdowngui-*.tmp")) == []
+
+
+@pytest.mark.skipif(
+    os.name == "nt", reason="POSIX symlinks are not portable to Windows"
+)
+def test_save_markdown_file_preserves_output_symlink(file_manager, tmp_path):
+    target = tmp_path / "reports" / "current.md"
+    target.parent.mkdir()
+    target.write_text("old output", encoding="utf-8")
+    output_link = tmp_path / "latest.md"
+    output_link.symlink_to(target.relative_to(output_link.parent))
+
+    file_manager.save_markdown_file(str(output_link), "new output")
+
+    assert output_link.is_symlink()
+    assert target.read_text(encoding="utf-8") == "new output"
+
+
+@pytest.mark.skipif(
+    os.name == "nt", reason="POSIX path limits are not portable to Windows"
+)
+def test_save_markdown_file_supports_long_destination_names(file_manager, tmp_path):
+    name_max = os.pathconf(tmp_path, "PC_NAME_MAX")
+    output_path = tmp_path / ("x" * (name_max - len(".md")) + ".md")
+
+    file_manager.save_markdown_file(str(output_path), "new output")
+
+    assert output_path.read_text(encoding="utf-8") == "new output"
 
 
 @pytest.mark.skipif(os.name == "nt", reason="POSIX permissions are not portable to Windows")
@@ -123,4 +151,4 @@ def test_stage_markdown_file_closes_descriptor_when_permission_setup_fails(
         file_manager.stage_markdown_file(str(output_path), "new output")
 
     assert len(closed_descriptors) == 1
-    assert list(tmp_path.glob(".report.md.*.tmp")) == []
+    assert list(tmp_path.glob(".markitdowngui-*.tmp")) == []

--- a/tests/core/test_markdown_assets.py
+++ b/tests/core/test_markdown_assets.py
@@ -117,7 +117,7 @@ def test_prepare_markdown_for_separate_save_supports_long_asset_root_names(tmp_p
     assert (asset_root / "page-1.png").is_file()
 
 
-def test_prepare_markdown_for_separate_save_refuses_to_replace_unowned_assets(
+def test_prepare_markdown_for_separate_save_uses_noncolliding_root_for_unowned_assets(
     tmp_path,
 ):
     asset_path = tmp_path / "temp-assets" / "page-1.png"
@@ -128,26 +128,22 @@ def test_prepare_markdown_for_separate_save_refuses_to_replace_unowned_assets(
     unowned_asset_root.mkdir()
     sentinel_path = unowned_asset_root / "user-file.txt"
     sentinel_path.write_text("keep me", encoding="utf-8")
-    (unowned_asset_root / ".markitdowngui-assets.json").write_text(
-        "{}",
-        encoding="utf-8",
+    markdown = prepare_markdown_for_separate_save(
+        "![page](C:/temp/run/report/page-1.png)",
+        [
+            _FakeAsset(
+                filename="page-1.png",
+                source_path=str(asset_path),
+                preview_markdown_path="C:/temp/run/report/page-1.png",
+            )
+        ],
+        output_path,
     )
-
-    with pytest.raises(FileExistsError, match="unowned asset directory"):
-        prepare_markdown_for_separate_save(
-            "![page](C:/temp/run/report/page-1.png)",
-            [
-                _FakeAsset(
-                    filename="page-1.png",
-                    source_path=str(asset_path),
-                    preview_markdown_path="C:/temp/run/report/page-1.png",
-                )
-            ],
-            output_path,
-        )
 
     assert sentinel_path.read_text(encoding="utf-8") == "keep me"
     assert not (unowned_asset_root / "page-1.png").exists()
+    assert "report_assets_1/page-1.png" in markdown
+    assert (tmp_path / "report_assets_1" / "page-1.png").read_bytes() == b"new-png"
 
 
 def test_prepare_markdown_for_separate_save_keeps_unowned_assets_when_no_assets(
@@ -341,7 +337,7 @@ def test_prepare_combined_markdown_for_save_scopes_documents_and_avoids_collisio
     assert (tmp_path / "combined_assets" / "002_report" / "page-1.png").is_file()
 
 
-def test_prepare_combined_markdown_for_save_refuses_to_replace_unowned_assets(
+def test_prepare_combined_markdown_for_save_uses_noncolliding_root_for_unowned_assets(
     tmp_path,
 ):
     asset_path = tmp_path / "temp-assets" / "page-1.png"
@@ -353,26 +349,27 @@ def test_prepare_combined_markdown_for_save_refuses_to_replace_unowned_assets(
     sentinel_path = unowned_asset_root / "user-file.txt"
     sentinel_path.write_text("keep me", encoding="utf-8")
 
-    with pytest.raises(FileExistsError, match="unowned asset directory"):
-        prepare_combined_markdown_for_save(
-            [
-                MarkdownSaveInput(
-                    source="C:/docs/report.pdf",
-                    markdown="![page](C:/temp/run/report/page-1.png)",
-                    assets=[
-                        _FakeAsset(
-                            filename="page-1.png",
-                            source_path=str(asset_path),
-                            preview_markdown_path="C:/temp/run/report/page-1.png",
-                        )
-                    ],
-                )
-            ],
-            output_path,
-            source_heading_template="Source: {source}",
-        )
+    markdown = prepare_combined_markdown_for_save(
+        [
+            MarkdownSaveInput(
+                source="C:/docs/report.pdf",
+                markdown="![page](C:/temp/run/report/page-1.png)",
+                assets=[
+                    _FakeAsset(
+                        filename="page-1.png",
+                        source_path=str(asset_path),
+                        preview_markdown_path="C:/temp/run/report/page-1.png",
+                    )
+                ],
+            )
+        ],
+        output_path,
+        source_heading_template="Source: {source}",
+    )
 
     assert sentinel_path.read_text(encoding="utf-8") == "keep me"
+    assert "combined_assets_1/001_report/page-1.png" in markdown
+    assert (tmp_path / "combined_assets_1" / "001_report" / "page-1.png").read_bytes() == b"new-png"
 
 
 def test_temp_asset_root_creation_and_cleanup():

--- a/tests/core/test_markdown_assets.py
+++ b/tests/core/test_markdown_assets.py
@@ -90,6 +90,33 @@ def test_prepare_markdown_for_separate_save_uses_normal_directory_permissions(
     assert asset_root_mode == 0o777 & ~current_umask
 
 
+@pytest.mark.skipif(
+    os.name == "nt", reason="POSIX path limits are not portable to Windows"
+)
+def test_prepare_markdown_for_separate_save_supports_long_asset_root_names(tmp_path):
+    name_max = os.pathconf(tmp_path, "PC_NAME_MAX")
+    output_path = tmp_path / ("x" * (name_max - len("_assets")) + ".md")
+    asset_path = tmp_path / "temp-assets" / "page-1.png"
+    asset_path.parent.mkdir(parents=True)
+    asset_path.write_bytes(b"png")
+
+    markdown = prepare_markdown_for_separate_save(
+        "![page](C:/temp/run/report/page-1.png)",
+        [
+            _FakeAsset(
+                filename="page-1.png",
+                source_path=str(asset_path),
+                preview_markdown_path="C:/temp/run/report/page-1.png",
+            )
+        ],
+        output_path,
+    )
+
+    asset_root = output_path.with_name(f"{output_path.stem}_assets")
+    assert f"{asset_root.name}/page-1.png" in markdown
+    assert (asset_root / "page-1.png").is_file()
+
+
 def test_prepare_markdown_for_separate_save_refuses_to_replace_unowned_assets(
     tmp_path,
 ):
@@ -173,7 +200,7 @@ def test_prepare_markdown_for_separate_save_replaces_only_app_owned_assets(tmp_p
     assert "report_assets/page-2.png" in markdown
     assert not (asset_root / "page-1.png").exists()
     assert (asset_root / "page-2.png").read_bytes() == b"second"
-    assert not list(tmp_path.glob(".report_assets.*.backup"))
+    assert not list(tmp_path.glob(".markitdowngui-assets-*.backup"))
 
 
 def test_prepare_markdown_for_separate_save_reserves_the_ownership_marker_name(
@@ -237,7 +264,7 @@ def test_prepare_markdown_for_separate_save_keeps_previous_owned_assets_on_copy_
         )
 
     assert (tmp_path / "report_assets" / "page-1.png").read_bytes() == b"first"
-    assert not list(tmp_path.glob(".report_assets.*.staging"))
+    assert not list(tmp_path.glob(".markitdowngui-assets-*.staging"))
 
 
 def test_prepare_markdown_for_separate_save_removes_only_owned_assets_when_empty(

--- a/tests/core/test_markdown_assets.py
+++ b/tests/core/test_markdown_assets.py
@@ -1,4 +1,6 @@
 from dataclasses import dataclass
+import os
+import stat
 
 import pytest
 
@@ -59,6 +61,33 @@ def test_prepare_markdown_for_separate_save_copies_assets_and_rewrites_paths(tmp
     assert "report_assets/page-1.png" in markdown
     assert "C:/temp/run/report/page-1.png" not in markdown
     assert (tmp_path / "report_assets" / "page-1.png").is_file()
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX directory modes are not available")
+def test_prepare_markdown_for_separate_save_uses_normal_directory_permissions(
+    tmp_path,
+):
+    asset_path = tmp_path / "temp-assets" / "page-1.png"
+    asset_path.parent.mkdir(parents=True)
+    asset_path.write_bytes(b"png")
+    output_path = tmp_path / "report.md"
+    current_umask = os.umask(0)
+    os.umask(current_umask)
+
+    prepare_markdown_for_separate_save(
+        "![page](C:/temp/run/report/page-1.png)",
+        [
+            _FakeAsset(
+                filename="page-1.png",
+                source_path=str(asset_path),
+                preview_markdown_path="C:/temp/run/report/page-1.png",
+            )
+        ],
+        output_path,
+    )
+
+    asset_root_mode = stat.S_IMODE((tmp_path / "report_assets").stat().st_mode)
+    assert asset_root_mode == 0o777 & ~current_umask
 
 
 def test_prepare_markdown_for_separate_save_refuses_to_replace_unowned_assets(

--- a/tests/core/test_markdown_assets.py
+++ b/tests/core/test_markdown_assets.py
@@ -1,5 +1,7 @@
 from dataclasses import dataclass
 
+import pytest
+
 from markitdowngui.core.markdown_assets import (
     MarkdownSaveInput,
     cleanup_temp_asset_root,
@@ -59,6 +61,182 @@ def test_prepare_markdown_for_separate_save_copies_assets_and_rewrites_paths(tmp
     assert (tmp_path / "report_assets" / "page-1.png").is_file()
 
 
+def test_prepare_markdown_for_separate_save_refuses_to_replace_unowned_assets(
+    tmp_path,
+):
+    asset_path = tmp_path / "temp-assets" / "page-1.png"
+    asset_path.parent.mkdir(parents=True)
+    asset_path.write_bytes(b"new-png")
+    output_path = tmp_path / "report.md"
+    unowned_asset_root = tmp_path / "report_assets"
+    unowned_asset_root.mkdir()
+    sentinel_path = unowned_asset_root / "user-file.txt"
+    sentinel_path.write_text("keep me", encoding="utf-8")
+    (unowned_asset_root / ".markitdowngui-assets.json").write_text(
+        "{}",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(FileExistsError, match="unowned asset directory"):
+        prepare_markdown_for_separate_save(
+            "![page](C:/temp/run/report/page-1.png)",
+            [
+                _FakeAsset(
+                    filename="page-1.png",
+                    source_path=str(asset_path),
+                    preview_markdown_path="C:/temp/run/report/page-1.png",
+                )
+            ],
+            output_path,
+        )
+
+    assert sentinel_path.read_text(encoding="utf-8") == "keep me"
+    assert not (unowned_asset_root / "page-1.png").exists()
+
+
+def test_prepare_markdown_for_separate_save_keeps_unowned_assets_when_no_assets(
+    tmp_path,
+):
+    output_path = tmp_path / "report.md"
+    unowned_asset_root = tmp_path / "report_assets"
+    unowned_asset_root.mkdir()
+    sentinel_path = unowned_asset_root / "user-file.txt"
+    sentinel_path.write_text("keep me", encoding="utf-8")
+
+    markdown = prepare_markdown_for_separate_save("# Report", [], output_path)
+
+    assert markdown == "# Report"
+    assert sentinel_path.read_text(encoding="utf-8") == "keep me"
+
+
+def test_prepare_markdown_for_separate_save_replaces_only_app_owned_assets(tmp_path):
+    first_asset = tmp_path / "temp-assets" / "page-1.png"
+    second_asset = tmp_path / "temp-assets" / "page-2.png"
+    first_asset.parent.mkdir(parents=True)
+    first_asset.write_bytes(b"first")
+    second_asset.write_bytes(b"second")
+    output_path = tmp_path / "report.md"
+
+    prepare_markdown_for_separate_save(
+        "![page](C:/temp/run/report/page-1.png)",
+        [
+            _FakeAsset(
+                filename="page-1.png",
+                source_path=str(first_asset),
+                preview_markdown_path="C:/temp/run/report/page-1.png",
+            )
+        ],
+        output_path,
+    )
+    markdown = prepare_markdown_for_separate_save(
+        "![page](C:/temp/run/report/page-2.png)",
+        [
+            _FakeAsset(
+                filename="page-2.png",
+                source_path=str(second_asset),
+                preview_markdown_path="C:/temp/run/report/page-2.png",
+            )
+        ],
+        output_path,
+    )
+
+    asset_root = tmp_path / "report_assets"
+    assert "report_assets/page-2.png" in markdown
+    assert not (asset_root / "page-1.png").exists()
+    assert (asset_root / "page-2.png").read_bytes() == b"second"
+    assert not list(tmp_path.glob(".report_assets.*.backup"))
+
+
+def test_prepare_markdown_for_separate_save_reserves_the_ownership_marker_name(
+    tmp_path,
+):
+    asset_path = tmp_path / "temp-assets" / ".markitdowngui-assets.json"
+    asset_path.parent.mkdir(parents=True)
+    asset_path.write_bytes(b"asset")
+    output_path = tmp_path / "report.md"
+
+    markdown = prepare_markdown_for_separate_save(
+        "[asset](C:/temp/run/report/manifest.json)",
+        [
+            _FakeAsset(
+                filename=".markitdowngui-assets.json",
+                source_path=str(asset_path),
+                preview_markdown_path="C:/temp/run/report/manifest.json",
+            )
+        ],
+        output_path,
+    )
+
+    asset_root = tmp_path / "report_assets"
+    assert "report_assets/.markitdowngui-assets_1.json" in markdown
+    assert (asset_root / ".markitdowngui-assets_1.json").read_bytes() == b"asset"
+    assert (asset_root / ".markitdowngui-assets.json").is_file()
+
+
+def test_prepare_markdown_for_separate_save_keeps_previous_owned_assets_on_copy_error(
+    tmp_path,
+):
+    first_asset = tmp_path / "temp-assets" / "page-1.png"
+    first_asset.parent.mkdir(parents=True)
+    first_asset.write_bytes(b"first")
+    output_path = tmp_path / "report.md"
+
+    prepare_markdown_for_separate_save(
+        "![page](C:/temp/run/report/page-1.png)",
+        [
+            _FakeAsset(
+                filename="page-1.png",
+                source_path=str(first_asset),
+                preview_markdown_path="C:/temp/run/report/page-1.png",
+            )
+        ],
+        output_path,
+    )
+
+    missing_asset = tmp_path / "temp-assets" / "missing.png"
+    with pytest.raises(FileNotFoundError, match="Missing asset file"):
+        prepare_markdown_for_separate_save(
+            "![page](C:/temp/run/report/missing.png)",
+            [
+                _FakeAsset(
+                    filename="missing.png",
+                    source_path=str(missing_asset),
+                    preview_markdown_path="C:/temp/run/report/missing.png",
+                )
+            ],
+            output_path,
+        )
+
+    assert (tmp_path / "report_assets" / "page-1.png").read_bytes() == b"first"
+    assert not list(tmp_path.glob(".report_assets.*.staging"))
+
+
+def test_prepare_markdown_for_separate_save_removes_only_owned_assets_when_empty(
+    tmp_path,
+):
+    asset_path = tmp_path / "temp-assets" / "page-1.png"
+    asset_path.parent.mkdir(parents=True)
+    asset_path.write_bytes(b"first")
+    output_path = tmp_path / "report.md"
+
+    prepare_markdown_for_separate_save(
+        "![page](C:/temp/run/report/page-1.png)",
+        [
+            _FakeAsset(
+                filename="page-1.png",
+                source_path=str(asset_path),
+                preview_markdown_path="C:/temp/run/report/page-1.png",
+            )
+        ],
+        output_path,
+    )
+
+    markdown = prepare_markdown_for_separate_save("# Report", [], output_path)
+
+    assert markdown == "# Report"
+    assert not (tmp_path / "report_assets").exists()
+
+
 def test_prepare_combined_markdown_for_save_scopes_documents_and_avoids_collisions(
     tmp_path,
 ):
@@ -105,6 +283,40 @@ def test_prepare_combined_markdown_for_save_scopes_documents_and_avoids_collisio
     assert "C:/temp/run/report-b/page-1.png" not in markdown
     assert (tmp_path / "combined_assets" / "001_report" / "page-1.png").is_file()
     assert (tmp_path / "combined_assets" / "002_report" / "page-1.png").is_file()
+
+
+def test_prepare_combined_markdown_for_save_refuses_to_replace_unowned_assets(
+    tmp_path,
+):
+    asset_path = tmp_path / "temp-assets" / "page-1.png"
+    asset_path.parent.mkdir(parents=True)
+    asset_path.write_bytes(b"new-png")
+    output_path = tmp_path / "combined.md"
+    unowned_asset_root = tmp_path / "combined_assets"
+    unowned_asset_root.mkdir()
+    sentinel_path = unowned_asset_root / "user-file.txt"
+    sentinel_path.write_text("keep me", encoding="utf-8")
+
+    with pytest.raises(FileExistsError, match="unowned asset directory"):
+        prepare_combined_markdown_for_save(
+            [
+                MarkdownSaveInput(
+                    source="C:/docs/report.pdf",
+                    markdown="![page](C:/temp/run/report/page-1.png)",
+                    assets=[
+                        _FakeAsset(
+                            filename="page-1.png",
+                            source_path=str(asset_path),
+                            preview_markdown_path="C:/temp/run/report/page-1.png",
+                        )
+                    ],
+                )
+            ],
+            output_path,
+            source_heading_template="Source: {source}",
+        )
+
+    assert sentinel_path.read_text(encoding="utf-8") == "keep me"
 
 
 def test_temp_asset_root_creation_and_cleanup():

--- a/tests/test_build_config.py
+++ b/tests/test_build_config.py
@@ -62,6 +62,7 @@ def test_build_datas_keeps_base_files_and_warns_for_missing_optional_packages():
     datas = build_config.build_datas(fake_collect, warn=warnings.append)
 
     assert ("LICENSE", ".") in datas
+    assert ("THIRD_PARTY_NOTICES.md", ".") in datas
     assert (
         "markitdowngui/resources/icons",
         "markitdowngui/resources/icons",

--- a/tests/ui_qml/test_controller.py
+++ b/tests/ui_qml/test_controller.py
@@ -455,6 +455,7 @@ def test_controller_confirms_before_starting_update_with_unsaved_results(
     asset = {
         "url": "https://example.com/windows.zip",
         "installSupported": True,
+        "installMode": "zip",
     }
     controller._preferred_release_asset = asset
     requests: list[str] = []
@@ -581,6 +582,38 @@ def test_controller_reports_manual_dmg_open_without_quitting(controller, monkeyp
             "Drag MarkItDown to Applications.",
         )
     ]
+
+
+def test_controller_keeps_unsaved_results_when_opening_manual_dmg(
+    controller, monkeypatch, tmp_path
+):
+    source = str(tmp_path / "result.pdf")
+    _complete_results(
+        controller,
+        {source: ConversionOutcome("# Converted", backend="native")},
+    )
+    asset = {
+        "name": "MarkItDown.dmg",
+        "url": "https://example.com/macos.dmg",
+        "installSupported": True,
+        "installMode": "dmg",
+    }
+    controller._preferred_release_asset = asset
+    requests: list[str] = []
+    created: list[dict[str, object]] = []
+    controller.discardResultsRequested.connect(requests.append)
+    monkeypatch.setattr(
+        controller,
+        "_create_update_installer",
+        lambda installed_asset: created.append(installed_asset)
+        or _FakeUpdateInstaller("manual"),
+    )
+
+    controller.installPreferredUpdate()
+
+    assert requests == []
+    assert created == [asset]
+    assert controller.hasResults is True
 
 
 def test_controller_blocks_update_install_while_converting(controller, monkeypatch):
@@ -1666,6 +1699,24 @@ def test_controller_disables_update_notifications_from_banner(controller, monkey
     assert controller.hasUpdateNotification is False
     assert controller.availableUpdateVersion == ""
     assert messages == [("success", "Update notifications disabled.")]
+
+
+def test_controller_enables_update_notifications_without_dismissing_update(controller):
+    controller.settings.set_update_notifications_enabled(False)
+    controller._available_update_version = "v1.2.0"
+    controller._available_release_url = "https://github.com/example/releases/tag/v1.2.0"
+    messages: list[tuple[str, str]] = []
+    changes: list[None] = []
+    controller.toastRequested.connect(lambda kind, message: messages.append((kind, message)))
+    controller.updateNotificationChanged.connect(lambda: changes.append(None))
+
+    controller.setUpdateNotificationsEnabled(True)
+
+    assert controller.settings.get_update_notifications_enabled() is True
+    assert controller.hasUpdateNotification is True
+    assert controller.availableUpdateVersion == "v1.2.0"
+    assert messages == []
+    assert changes == [None]
 
 
 def test_controller_locks_queue_mutations_while_converting(controller, tmp_path):

--- a/tests/ui_qml/test_controller.py
+++ b/tests/ui_qml/test_controller.py
@@ -162,11 +162,40 @@ def test_controller_add_url_rejects_invalid_url(controller):
 
 
 def test_controller_add_url_queues_valid_url(controller):
-    controller.addUrl("https://example.com/article")
+    assert controller.addUrl("https://example.com/article") is True
 
     assert controller.queue_model.sources() == ["https://example.com/article"]
     assert controller.hasQueue is True
     assert controller.queueCount == 1
+
+
+def test_controller_add_url_waits_for_discard_confirmation(controller, tmp_path):
+    source = str(tmp_path / "existing.pdf")
+    url = "https://example.com/article"
+    controller.addFiles([source])
+    _complete_results(
+        controller,
+        {source: ConversionOutcome("# Existing", backend="native")},
+    )
+    requests: list[str] = []
+    queued_urls: list[str] = []
+    controller.discardResultsRequested.connect(requests.append)
+    controller.urlQueued.connect(queued_urls.append)
+
+    assert controller.addUrl(url) is False
+    assert requests == ["add inputs to the queue"]
+    assert queued_urls == []
+
+    controller.cancelPendingResultDiscard()
+
+    assert controller.queue_model.sources() == [source]
+    assert queued_urls == []
+
+    assert controller.addUrl(url) is False
+    controller.discardPendingResults()
+
+    assert controller.queue_model.sources() == [source, url]
+    assert queued_urls == [url]
 
 
 def test_controller_auto_update_check_respects_disabled_setting(controller, monkeypatch):
@@ -1831,6 +1860,32 @@ def test_controller_save_separate_skips_failed_results(controller, tmp_path):
     assert controller.hasUnsavedSuccessfulResults is False
 
 
+def test_controller_save_separate_reports_partial_save_failures(controller, tmp_path, monkeypatch):
+    output_dir = tmp_path / "exports"
+    _complete_results(
+        controller,
+        {
+            "C:/tmp/ok.pdf": ConversionOutcome("# Converted", backend="native"),
+            "C:/tmp/fail.pdf": ConversionOutcome("# Also converted", backend="native"),
+        },
+    )
+    original_save = controller._save_prepared_markdown
+
+    def fail_one_output(output_path, prepared_output):
+        if output_path.endswith("fail.md"):
+            raise OSError("disk full")
+        original_save(output_path, prepared_output)
+
+    monkeypatch.setattr(controller, "_save_prepared_markdown", fail_one_output)
+    messages: list[tuple[str, str]] = []
+    controller.toastRequested.connect(lambda kind, message: messages.append((kind, message)))
+
+    controller.saveSeparateOutputs(str(output_dir))
+
+    assert messages == [("error", "Saved 1 file; 1 file failed to save.")]
+    assert controller.hasUnsavedSuccessfulResults is True
+
+
 def test_controller_restores_asset_root_when_markdown_replace_fails(
     controller,
     monkeypatch,
@@ -2357,4 +2412,3 @@ def test_controller_exposes_selected_failed_result(controller):
 
     controller.selectResult(1)
     assert controller.selectedResultFailed is True
-

--- a/tests/ui_qml/test_controller.py
+++ b/tests/ui_qml/test_controller.py
@@ -444,6 +444,46 @@ def test_controller_installs_supported_preferred_update(controller, monkeypatch)
     assert controller.hasUpdateNotification is False
 
 
+def test_controller_confirms_before_starting_update_with_unsaved_results(
+    controller, monkeypatch, tmp_path
+):
+    source = str(tmp_path / "result.pdf")
+    _complete_results(
+        controller,
+        {source: ConversionOutcome("# Converted", backend="native")},
+    )
+    asset = {
+        "url": "https://example.com/windows.zip",
+        "installSupported": True,
+    }
+    controller._preferred_release_asset = asset
+    requests: list[str] = []
+    created: list[dict[str, object]] = []
+    quit_calls: list[None] = []
+    controller.discardResultsRequested.connect(requests.append)
+    monkeypatch.setattr(
+        controller,
+        "_create_update_installer",
+        lambda asset: created.append(asset) or _FakeUpdateInstaller(),
+    )
+    monkeypatch.setattr(
+        "markitdowngui.ui_qml.controller.QGuiApplication.quit",
+        lambda: quit_calls.append(None),
+    )
+
+    controller.installPreferredUpdate()
+
+    assert requests == ["install the update and close the application"]
+    assert created == []
+    assert quit_calls == []
+
+    controller.discardPendingResults()
+
+    assert controller.hasResults is False
+    assert created == [asset]
+    assert quit_calls == [None]
+
+
 def test_packaged_update_installer_emits_progress_and_success(monkeypatch):
     progress: list[tuple[str, int]] = []
     started: list[None] = []
@@ -934,6 +974,36 @@ def test_controller_skips_ocr_preflight_without_ocr_inputs(controller, monkeypat
     )
 
     assert controller._preflight_conversion() is True
+
+
+def test_controller_preflights_only_failed_inputs_before_retry(controller, monkeypatch):
+    pdf_source = "C:/tmp/successful.pdf"
+    url_source = "https://example.com/retry"
+    controller.addFiles([pdf_source, url_source])
+    _complete_results(
+        controller,
+        {
+            pdf_source: ConversionOutcome("# PDF", backend="native"),
+            url_source: ConversionOutcome("# Failed", backend="defuddle"),
+        },
+        failed_sources={url_source},
+    )
+    controller.setOcrEnabled(True)
+    starts: list[dict[str, bool]] = []
+    monkeypatch.setattr(
+        "markitdowngui.ui_qml.controller.validate_ocr_setup",
+        lambda _options: pytest.fail("the failed URL does not need OCR setup"),
+    )
+    monkeypatch.setattr(
+        controller,
+        "_start_conversion",
+        lambda **kwargs: starts.append(kwargs),
+    )
+
+    controller.retryFailedResults()
+
+    assert controller.queue_model.sources() == [url_source]
+    assert starts == [{"preserve_results": True, "preflight_validated": True}]
 
 
 def test_controller_tests_ocr_connection(controller, monkeypatch):
@@ -2017,9 +2087,9 @@ def test_controller_restores_asset_root_when_markdown_replace_fails(
 
     assert output_path.read_text(encoding="utf-8") == old_markdown
     assert (tmp_path / "report_assets" / "page.png").read_bytes() == b"old asset"
-    assert not list(tmp_path.glob(".report_assets.*.backup"))
-    assert not list(tmp_path.glob(".report_assets.*.staging"))
-    assert not list(tmp_path.glob(".report.md.*.tmp"))
+    assert not list(tmp_path.glob(".markitdowngui-assets-*.backup"))
+    assert not list(tmp_path.glob(".markitdowngui-assets-*.staging"))
+    assert not list(tmp_path.glob(".markitdowngui-*.tmp"))
 
 
 def test_controller_restores_owned_assets_when_asset_free_save_fails(
@@ -2065,7 +2135,7 @@ def test_controller_restores_owned_assets_when_asset_free_save_fails(
 
     assert output_path.read_text(encoding="utf-8") == old_markdown
     assert (tmp_path / "report_assets" / "page.png").read_bytes() == b"old asset"
-    assert not list(tmp_path.glob(".report_assets.*.backup"))
+    assert not list(tmp_path.glob(".markitdowngui-assets-*.backup"))
 
 
 def test_controller_save_all_failed_results_reports_no_success(controller, tmp_path):

--- a/tests/ui_qml/test_controller.py
+++ b/tests/ui_qml/test_controller.py
@@ -4,7 +4,11 @@ from types import SimpleNamespace
 import pytest
 from PySide6.QtCore import QSettings, QUrl
 
-from markitdowngui.core.conversion import ConversionOutcome
+from markitdowngui.core.conversion import ConversionAsset, ConversionOutcome
+from markitdowngui.core.markdown_assets import (
+    prepare_markdown_for_separate_save,
+    prepare_markdown_for_separate_save_transaction,
+)
 from markitdowngui.core.settings import SettingsManager
 from markitdowngui.ui_qml.controller import (
     AppController,
@@ -132,6 +136,19 @@ def controller(tmp_path):
     )
     controller.settings = settings
     return controller
+
+
+def _complete_results(
+    controller: AppController,
+    results: dict[str, ConversionOutcome],
+    failed_sources: set[str] | None = None,
+) -> None:
+    controller.worker = SimpleNamespace(
+        is_cancelled=False,
+        failed_files=failed_sources or set(),
+    )
+    controller._converting = True
+    controller._handle_finished(results)
 
 
 def test_controller_add_url_rejects_invalid_url(controller):
@@ -853,6 +870,30 @@ def test_controller_reports_ocr_validation_error(controller, monkeypatch):
     assert messages == [("error", "HTTP OCR requires an endpoint URL.")]
 
 
+def test_controller_preflights_ocr_before_starting_a_conversion(controller, monkeypatch):
+    messages: list[tuple[str, str]] = []
+    controller.toastRequested.connect(lambda kind, message: messages.append((kind, message)))
+    controller.addFiles(["C:/tmp/scan.pdf"])
+    controller.setOcrEnabled(True)
+    monkeypatch.setattr(
+        "markitdowngui.ui_qml.controller.validate_ocr_setup",
+        lambda _options: SimpleNamespace(
+            ok=False,
+            message="HTTP OCR requires an endpoint URL.",
+        ),
+    )
+    monkeypatch.setattr(
+        "markitdowngui.ui_qml.controller.ConversionWorker",
+        lambda **_kwargs: pytest.fail("worker should not start after failed preflight"),
+    )
+
+    controller.convert()
+
+    assert controller.converting is False
+    assert controller.statusText == "OCR setup needs attention"
+    assert messages == [("error", "HTTP OCR requires an endpoint URL.")]
+
+
 def test_controller_tests_ocr_connection(controller, monkeypatch):
     messages: list[tuple[str, str]] = []
     controller.toastRequested.connect(
@@ -945,6 +986,38 @@ def test_diagnostic_readiness_does_not_create_temp_asset_root(controller, monkey
     )
 
     controller.diagnosticReadinessItems
+
+
+def test_controller_retains_all_asset_roots_while_results_are_kept(
+    controller,
+    monkeypatch,
+    tmp_path,
+):
+    first_root = tmp_path / "first-assets"
+    second_root = tmp_path / "second-assets"
+    first_root.mkdir()
+    second_root.mkdir()
+    roots = iter([first_root, second_root])
+    cleaned: list[str] = []
+    controller.setPreservePdfImages(True)
+    monkeypatch.setattr(
+        "markitdowngui.ui_qml.controller.create_temp_asset_root",
+        lambda: next(roots),
+    )
+    monkeypatch.setattr(
+        "markitdowngui.ui_qml.controller.cleanup_temp_asset_root",
+        lambda path: cleaned.append(str(path)),
+    )
+
+    first_options = controller._build_conversion_options()
+    second_options = controller._build_conversion_options()
+
+    assert first_options.pdf_artifacts_dir == str(first_root)
+    assert second_options.pdf_artifacts_dir == str(second_root)
+
+    controller._cleanup_temp_assets()
+
+    assert set(cleaned) == {str(first_root), str(second_root)}
 
 
 def test_controller_copies_source_update_command(controller, monkeypatch):
@@ -1442,47 +1515,78 @@ def test_controller_locks_queue_mutations_while_converting(controller, tmp_path)
     ]
 
 
-def test_controller_add_files_invalidates_stale_results(controller, tmp_path):
+def test_controller_add_files_requires_discarding_unsaved_results(controller, tmp_path):
     source_a = str(tmp_path / "a.pdf")
     source_b = str(tmp_path / "b.pdf")
     controller.addFiles([source_a])
-    controller.result_model.set_results(
-        {source_a: ConversionOutcome("# Converted", backend="native")}
+    _complete_results(
+        controller,
+        {source_a: ConversionOutcome("# Converted", backend="native")},
     )
-    controller.selectResult(0)
+    requests: list[str] = []
+    controller.discardResultsRequested.connect(requests.append)
 
     controller.addFiles([source_b])
+
+    assert requests == ["add inputs to the queue"]
+    assert controller.hasUnsavedSuccessfulResults is True
+    assert controller.result_model.rowCount() == 1
+    assert controller.queue_model.sources() == [source_a]
+
+    controller.cancelPendingResultDiscard()
+
+    assert controller.result_model.rowCount() == 1
+    assert controller.queue_model.sources() == [source_a]
+
+    controller.addFiles([source_b])
+    controller.discardPendingResults()
 
     assert controller.result_model.rowCount() == 0
     assert controller.selectedResultIndex == -1
     assert controller.queue_model.sources() == [source_a, source_b]
 
 
-def test_controller_remove_queued_invalidates_stale_results(controller, tmp_path):
+def test_controller_remove_queued_requires_discarding_unsaved_results(controller, tmp_path):
     source_a = str(tmp_path / "a.pdf")
     source_b = str(tmp_path / "b.pdf")
     controller.addFiles([source_a, source_b])
-    controller.result_model.set_results(
-        {source_a: ConversionOutcome("# Converted", backend="native")}
+    _complete_results(
+        controller,
+        {source_a: ConversionOutcome("# Converted", backend="native")},
     )
-    controller.selectResult(0)
+    requests: list[str] = []
+    controller.discardResultsRequested.connect(requests.append)
 
     controller.removeQueued(0)
+
+    assert requests == ["change the queue"]
+    assert controller.result_model.rowCount() == 1
+    assert controller.queue_model.sources() == [source_a, source_b]
+
+    controller.discardPendingResults()
 
     assert controller.result_model.rowCount() == 0
     assert controller.selectedResultIndex == -1
     assert controller.queue_model.sources() == [source_b]
 
 
-def test_controller_clear_queue_invalidates_stale_results(controller, tmp_path):
+def test_controller_clear_queue_requires_discarding_unsaved_results(controller, tmp_path):
     source = str(tmp_path / "a.pdf")
     controller.addFiles([source])
-    controller.result_model.set_results(
-        {source: ConversionOutcome("# Converted", backend="native")}
+    _complete_results(
+        controller,
+        {source: ConversionOutcome("# Converted", backend="native")},
     )
-    controller.selectResult(0)
+    requests: list[str] = []
+    controller.discardResultsRequested.connect(requests.append)
 
     controller.clearQueue()
+
+    assert requests == ["clear the queue"]
+    assert controller.result_model.rowCount() == 1
+    assert controller.queue_model.sources() == [source]
+
+    controller.discardPendingResults()
 
     assert controller.result_model.rowCount() == 0
     assert controller.selectedResultIndex == -1
@@ -1500,6 +1604,107 @@ def test_controller_clear_empty_queue_invalidates_stale_results(controller):
     assert controller.result_model.rowCount() == 0
     assert controller.selectedResultIndex == -1
     assert controller.queue_model.sources() == []
+
+
+def test_controller_back_to_queue_requires_discarding_unsaved_results(controller, tmp_path):
+    source = str(tmp_path / "a.pdf")
+    controller.addFiles([source])
+    _complete_results(
+        controller,
+        {source: ConversionOutcome("# Converted", backend="native")},
+    )
+    requests: list[str] = []
+    controller.discardResultsRequested.connect(requests.append)
+
+    controller.backToQueue()
+
+    assert requests == ["return to the queue"]
+    assert controller.hasResults is True
+    assert controller.queue_model.sources() == [source]
+
+    controller.discardPendingResults()
+
+    assert controller.hasResults is False
+    assert controller.queue_model.sources() == [source]
+
+
+def test_controller_start_new_requires_discarding_unsaved_results(controller, tmp_path):
+    source = str(tmp_path / "a.pdf")
+    controller.addFiles([source])
+    _complete_results(
+        controller,
+        {source: ConversionOutcome("# Converted", backend="native")},
+    )
+    requests: list[str] = []
+    controller.discardResultsRequested.connect(requests.append)
+
+    controller.startNew()
+
+    assert requests == ["start a new conversion"]
+    assert controller.hasResults is True
+    assert controller.queue_model.sources() == [source]
+
+    controller.discardPendingResults()
+
+    assert controller.hasResults is False
+    assert controller.queue_model.sources() == []
+
+
+def test_controller_confirms_before_closing_with_unsaved_results(controller, tmp_path):
+    source = str(tmp_path / "a.pdf")
+    controller.addFiles([source])
+    _complete_results(
+        controller,
+        {source: ConversionOutcome("# Converted", backend="native")},
+    )
+    requests: list[str] = []
+    close_approved: list[None] = []
+    controller.discardResultsRequested.connect(requests.append)
+    controller.closeApproved.connect(lambda: close_approved.append(None))
+
+    assert controller.requestShutdown() is False
+    assert requests == ["close the application"]
+    assert controller.hasResults is True
+
+    controller.cancelPendingResultDiscard()
+    assert controller.hasResults is True
+    assert close_approved == []
+
+    assert controller.requestShutdown() is False
+    controller.discardPendingResults()
+
+    assert controller.hasResults is False
+    assert close_approved == [None]
+
+
+def test_controller_stops_active_conversion_before_discarding_for_close(
+    controller,
+    monkeypatch,
+):
+    source = "C:/tmp/report.pdf"
+    controller.result_model.set_results(
+        {source: ConversionOutcome("# Converted", backend="native")}
+    )
+    controller._unsaved_result_sources.add(source)
+    controller._temp_asset_root = "C:/tmp/markitdown-assets"
+    events: list[str] = []
+    controller.worker = SimpleNamespace(
+        is_cancelled=False,
+        is_paused=False,
+        isRunning=lambda: True,
+        wait=lambda _timeout: events.append("wait") or True,
+    )
+    monkeypatch.setattr(
+        "markitdowngui.ui_qml.controller.cleanup_temp_asset_root",
+        lambda path: events.append(f"cleanup:{path}"),
+    )
+
+    assert controller.requestShutdown() is False
+    controller.discardPendingResults()
+
+    assert controller.worker.is_cancelled is True
+    assert events == ["wait", "cleanup:C:/tmp/markitdown-assets"]
+    assert controller.hasResults is False
 
 
 def test_controller_notifies_before_save_dialog_when_no_output(controller):
@@ -1580,7 +1785,8 @@ def test_controller_separate_save_requires_fallback_for_web_sources(
 
 def test_controller_save_combined_skips_failed_results(controller, tmp_path):
     output_path = tmp_path / "combined.md"
-    controller.result_model.set_results(
+    _complete_results(
+        controller,
         {
             "C:/tmp/ok.pdf": ConversionOutcome("# Converted\n\nBody", backend="native"),
             "C:/tmp/broken.pdf": ConversionOutcome(
@@ -1592,6 +1798,7 @@ def test_controller_save_combined_skips_failed_results(controller, tmp_path):
     )
 
     assert controller.hasSuccessfulResults is True
+    assert controller.hasUnsavedSuccessfulResults is True
 
     controller.saveCombinedOutput(str(output_path))
 
@@ -1599,11 +1806,13 @@ def test_controller_save_combined_skips_failed_results(controller, tmp_path):
     assert "# Converted" in saved
     assert "Error converting broken.pdf" not in saved
     assert "C:/tmp/broken.pdf" not in saved
+    assert controller.hasUnsavedSuccessfulResults is False
 
 
 def test_controller_save_separate_skips_failed_results(controller, tmp_path):
     output_dir = tmp_path / "exports"
-    controller.result_model.set_results(
+    _complete_results(
+        controller,
         {
             "C:/tmp/ok.pdf": ConversionOutcome("# Converted\n\nBody", backend="native"),
             "C:/tmp/broken.pdf": ConversionOutcome(
@@ -1619,6 +1828,114 @@ def test_controller_save_separate_skips_failed_results(controller, tmp_path):
     saved_files = sorted(path.name for path in output_dir.glob("*.md"))
     assert saved_files == ["ok.md"]
     assert (output_dir / "ok.md").read_text(encoding="utf-8") == "# Converted\n\nBody"
+    assert controller.hasUnsavedSuccessfulResults is False
+
+
+def test_controller_restores_asset_root_when_markdown_replace_fails(
+    controller,
+    monkeypatch,
+    tmp_path,
+):
+    output_path = tmp_path / "report.md"
+    old_asset_path = tmp_path / "source" / "old.png"
+    new_asset_path = tmp_path / "source" / "new.png"
+    old_asset_path.parent.mkdir()
+    old_asset_path.write_bytes(b"old asset")
+    new_asset_path.write_bytes(b"new asset")
+    old_asset = ConversionAsset(
+        filename="page.png",
+        source_path=str(old_asset_path),
+        preview_markdown_path="C:/temp/old.png",
+        page_number=None,
+        kind="image",
+    )
+    new_asset = ConversionAsset(
+        filename="page.png",
+        source_path=str(new_asset_path),
+        preview_markdown_path="C:/temp/new.png",
+        page_number=None,
+        kind="image",
+    )
+    old_markdown = prepare_markdown_for_separate_save(
+        "# Old\n![old](C:/temp/old.png)",
+        [old_asset],
+        output_path,
+    )
+    controller.file_manager.save_markdown_file(str(output_path), old_markdown)
+    prepared = prepare_markdown_for_separate_save_transaction(
+        "# New\n![new](C:/temp/new.png)",
+        [new_asset],
+        output_path,
+    )
+    staged_file = controller.file_manager.stage_markdown_file(
+        str(output_path),
+        prepared.markdown,
+    )
+    monkeypatch.setattr(
+        controller.file_manager,
+        "stage_markdown_file",
+        lambda *_args: staged_file,
+    )
+    monkeypatch.setattr(
+        staged_file,
+        "commit",
+        lambda: (_ for _ in ()).throw(OSError("disk is unavailable")),
+    )
+
+    with pytest.raises(OSError, match="disk is unavailable"):
+        controller._save_prepared_markdown(str(output_path), prepared)
+
+    assert output_path.read_text(encoding="utf-8") == old_markdown
+    assert (tmp_path / "report_assets" / "page.png").read_bytes() == b"old asset"
+    assert not list(tmp_path.glob(".report_assets.*.backup"))
+    assert not list(tmp_path.glob(".report_assets.*.staging"))
+    assert not list(tmp_path.glob(".report.md.*.tmp"))
+
+
+def test_controller_restores_owned_assets_when_asset_free_save_fails(
+    controller,
+    monkeypatch,
+    tmp_path,
+):
+    output_path = tmp_path / "report.md"
+    asset_path = tmp_path / "source" / "page.png"
+    asset_path.parent.mkdir()
+    asset_path.write_bytes(b"old asset")
+    asset = ConversionAsset(
+        filename="page.png",
+        source_path=str(asset_path),
+        preview_markdown_path="C:/temp/page.png",
+        page_number=None,
+        kind="image",
+    )
+    old_markdown = prepare_markdown_for_separate_save(
+        "# Old\n![page](C:/temp/page.png)",
+        [asset],
+        output_path,
+    )
+    controller.file_manager.save_markdown_file(str(output_path), old_markdown)
+    prepared = prepare_markdown_for_separate_save_transaction("# New", [], output_path)
+    staged_file = controller.file_manager.stage_markdown_file(
+        str(output_path),
+        prepared.markdown,
+    )
+    monkeypatch.setattr(
+        controller.file_manager,
+        "stage_markdown_file",
+        lambda *_args: staged_file,
+    )
+    monkeypatch.setattr(
+        staged_file,
+        "commit",
+        lambda: (_ for _ in ()).throw(OSError("disk is unavailable")),
+    )
+
+    with pytest.raises(OSError, match="disk is unavailable"):
+        controller._save_prepared_markdown(str(output_path), prepared)
+
+    assert output_path.read_text(encoding="utf-8") == old_markdown
+    assert (tmp_path / "report_assets" / "page.png").read_bytes() == b"old asset"
+    assert not list(tmp_path.glob(".report_assets.*.backup"))
 
 
 def test_controller_save_all_failed_results_reports_no_success(controller, tmp_path):
@@ -1669,6 +1986,27 @@ def test_controller_finished_status_reports_mixed_failures(controller):
     assert messages == [("error", "1 conversion failed.")]
 
 
+def test_controller_exposes_completed_items_before_the_worker_finishes(controller):
+    controller._handle_item_finished(
+        "C:/tmp/first.pdf",
+        ConversionOutcome("# First", backend="native"),
+        False,
+    )
+
+    assert controller.result_model.rowCount() == 1
+    assert controller.selectedResultIndex == 0
+    assert controller.hasUnsavedSuccessfulResults is True
+
+    controller.worker = SimpleNamespace(is_cancelled=False, failed_files=set())
+    controller._converting = True
+    controller._handle_finished(
+        {"C:/tmp/first.pdf": ConversionOutcome("# First", backend="native")}
+    )
+
+    assert controller.result_model.rowCount() == 1
+    assert controller.hasUnsavedSuccessfulResults is True
+
+
 def test_controller_finished_status_reports_all_failed(controller):
     messages: list[tuple[str, str]] = []
     controller.toastRequested.connect(
@@ -1689,18 +2027,30 @@ def test_controller_finished_status_reports_all_failed(controller):
     assert messages == [("error", "1 conversion failed.")]
 
 
-def test_controller_retries_failed_results(controller):
+def test_controller_retries_failed_results_without_discarding_successes(
+    controller,
+    monkeypatch,
+):
     messages: list[tuple[str, str]] = []
     changes: list[str] = []
+    requests: list[str] = []
+    starts: list[dict[str, bool]] = []
     controller.toastRequested.connect(
         lambda kind, message: messages.append((kind, message))
     )
     controller.queueChanged.connect(lambda: changes.append("queue"))
     controller.resultsChanged.connect(lambda: changes.append("results"))
     controller.selectedResultChanged.connect(lambda: changes.append("selected"))
+    controller.discardResultsRequested.connect(requests.append)
+    monkeypatch.setattr(
+        controller,
+        "_start_conversion",
+        lambda **kwargs: starts.append(kwargs),
+    )
     controller.addFiles(["C:/tmp/original.pdf"])
     changes.clear()
-    controller.result_model.set_results(
+    _complete_results(
+        controller,
         {
             "C:/tmp/ok.pdf": ConversionOutcome("# Converted", backend="native"),
             "C:/tmp/broken-a.pdf": ConversionOutcome("A failed", backend="native"),
@@ -1710,21 +2060,27 @@ def test_controller_retries_failed_results(controller):
     )
     controller.selectResult(1)
     changes.clear()
+    messages.clear()
 
     assert controller.hasFailedResults is True
     assert controller.failedResultCount == 2
+    assert controller.hasUnsavedSuccessfulResults is True
 
     controller.retryFailedResults()
 
+    assert requests == []
     assert controller.queue_model.sources() == [
         "C:/tmp/broken-a.pdf",
         "https://example.com/broken",
     ]
-    assert controller.hasResults is False
-    assert controller.selectedResultIndex == -1
-    assert controller.statusText == "Queued 2 failed inputs for retry"
-    assert messages == [("success", "Queued 2 failed inputs for retry.")]
-    assert changes == ["results", "selected", "queue"]
+    assert controller.hasResults is True
+    assert controller.hasFailedResults is False
+    assert controller.result_model.item_at(0).source == "C:/tmp/ok.pdf"
+    assert controller.selectedResultIndex == 0
+    assert controller.hasUnsavedSuccessfulResults is True
+    assert starts == [{"preserve_results": True, "preflight_validated": True}]
+    assert messages == [("success", "Retrying 2 failed inputs.")]
+    assert changes == ["queue", "results", "selected"]
 
 
 def test_controller_retry_failed_results_reports_when_none_failed(controller):
@@ -1743,6 +2099,46 @@ def test_controller_retry_failed_results_reports_when_none_failed(controller):
     assert controller.hasFailedResults is False
     assert controller.failedResultCount == 0
     assert messages == [("error", "No failed conversions to retry.")]
+
+
+def test_controller_can_save_retained_successes_while_retrying_failures(
+    controller,
+    monkeypatch,
+    tmp_path,
+):
+    output_path = tmp_path / "converted.md"
+    starts: list[dict[str, bool]] = []
+    monkeypatch.setattr(
+        controller,
+        "_start_conversion",
+        lambda **kwargs: starts.append(kwargs),
+    )
+    controller.addFiles(["C:/tmp/original.pdf"])
+    _complete_results(
+        controller,
+        {
+            "C:/tmp/ok.pdf": ConversionOutcome("# Converted", backend="native"),
+            "C:/tmp/broken.pdf": ConversionOutcome("Conversion failed", backend="native"),
+        },
+        {"C:/tmp/broken.pdf"},
+    )
+    requests: list[str] = []
+    controller.discardResultsRequested.connect(requests.append)
+
+    controller.retryFailedResults()
+
+    assert requests == []
+    assert controller.hasResults is True
+    assert controller.hasFailedResults is False
+    assert controller.queue_model.sources() == ["C:/tmp/broken.pdf"]
+    assert starts == [{"preserve_results": True, "preflight_validated": True}]
+
+    controller.saveCombinedOutput(str(output_path))
+
+    saved = output_path.read_text(encoding="utf-8")
+    assert "# Converted" in saved
+    assert "broken.pdf" not in saved
+    assert controller.hasUnsavedSuccessfulResults is False
 
 
 def test_controller_separate_save_falls_back_when_source_folder_is_not_writable(

--- a/tests/ui_qml/test_controller.py
+++ b/tests/ui_qml/test_controller.py
@@ -923,6 +923,19 @@ def test_controller_preflights_ocr_before_starting_a_conversion(controller, monk
     assert messages == [("error", "HTTP OCR requires an endpoint URL.")]
 
 
+def test_controller_skips_ocr_preflight_without_ocr_inputs(controller, monkeypatch):
+    controller.addFiles(
+        ["https://example.com/article", "C:/tmp/presentation.pptx", "C:/tmp/readme.txt"]
+    )
+    controller.setOcrEnabled(True)
+    monkeypatch.setattr(
+        "markitdowngui.ui_qml.controller.validate_ocr_setup",
+        lambda _options: pytest.fail("native and URL inputs should not need OCR setup"),
+    )
+
+    assert controller._preflight_conversion() is True
+
+
 def test_controller_tests_ocr_connection(controller, monkeypatch):
     messages: list[tuple[str, str]] = []
     controller.toastRequested.connect(
@@ -1193,6 +1206,68 @@ def test_controller_restarts_app(controller, monkeypatch):
     assert started == [None]
     assert quit_calls == [None]
     assert messages == [("success", "Restarting app.")]
+
+
+def test_controller_confirms_before_restarting_with_unsaved_results(
+    controller, monkeypatch, tmp_path
+):
+    source = str(tmp_path / "result.pdf")
+    _complete_results(
+        controller,
+        {source: ConversionOutcome("# Converted", backend="native")},
+    )
+    requests: list[str] = []
+    started: list[None] = []
+    quit_calls: list[None] = []
+    controller.discardResultsRequested.connect(requests.append)
+    monkeypatch.setattr(
+        controller,
+        "_start_restart_process",
+        lambda: started.append(None) or True,
+    )
+    monkeypatch.setattr(
+        "markitdowngui.ui_qml.controller.QGuiApplication.quit",
+        lambda: quit_calls.append(None),
+    )
+
+    controller.restartApp()
+
+    assert requests == ["restart the application"]
+    assert started == []
+    assert quit_calls == []
+
+    controller.discardPendingResults()
+
+    assert controller.hasResults is False
+    assert started == [None]
+    assert quit_calls == [None]
+
+
+def test_controller_confirms_before_closing_for_update_with_unsaved_results(
+    controller, monkeypatch, tmp_path
+):
+    source = str(tmp_path / "result.pdf")
+    _complete_results(
+        controller,
+        {source: ConversionOutcome("# Converted", backend="native")},
+    )
+    requests: list[str] = []
+    quit_calls: list[None] = []
+    controller.discardResultsRequested.connect(requests.append)
+    monkeypatch.setattr(
+        "markitdowngui.ui_qml.controller.QGuiApplication.quit",
+        lambda: quit_calls.append(None),
+    )
+
+    controller._on_update_install_started()
+
+    assert requests == ["close the application and install the update"]
+    assert quit_calls == []
+
+    controller.discardPendingResults()
+
+    assert controller.hasResults is False
+    assert quit_calls == [None]
 
 
 def test_controller_reports_restart_failure(controller, monkeypatch):

--- a/tests/ui_qml/test_models.py
+++ b/tests/ui_qml/test_models.py
@@ -38,3 +38,41 @@ def test_result_model_exposes_backend_and_failure_state():
     assert model.data(index, ResultModel.FailedRole) is True
     assert model.data(index, ResultModel.WordCountRole) == 2
 
+
+def test_result_model_add_result_preserves_existing_completed_items():
+    model = ResultModel()
+    model.add_result(
+        "C:/tmp/first.pdf",
+        ConversionOutcome(markdown="first", backend="native"),
+    )
+    model.add_result(
+        "C:/tmp/second.pdf",
+        ConversionOutcome(markdown="second", backend="http-ocr"),
+        failed=True,
+    )
+    model.add_result(
+        "C:/tmp/first.pdf",
+        ConversionOutcome(markdown="first revised", backend="native"),
+    )
+
+    assert model.rowCount() == 2
+    assert model.item_at(0).outcome.markdown == "first revised"
+    assert model.item_at(1).failed is True
+    assert model.data(model.index(1, 0), ResultModel.BackendRole) == "HTTP OCR"
+
+
+def test_result_model_removes_only_sources_that_are_being_retried():
+    model = ResultModel()
+    model.set_results(
+        {
+            "C:/tmp/ok.pdf": ConversionOutcome("ok", backend="native"),
+            "C:/tmp/broken.pdf": ConversionOutcome("failed", backend="native"),
+        },
+        {"C:/tmp/broken.pdf"},
+    )
+
+    model.remove_sources({"C:/tmp/broken.pdf"})
+
+    assert model.rowCount() == 1
+    assert model.item_at(0).source == "C:/tmp/ok.pdf"
+

--- a/tests/ui_qml/test_qml_load.py
+++ b/tests/ui_qml/test_qml_load.py
@@ -1,15 +1,38 @@
 from pathlib import Path
 
-from PySide6.QtCore import QCoreApplication, QSettings, QUrl, Qt
-from PySide6.QtGui import QGuiApplication
+from PySide6.QtCore import QCoreApplication, QObject, QSettings, QUrl, Qt
+from PySide6.QtGui import QAccessible, QColor, QGuiApplication
 from PySide6.QtQml import QQmlApplicationEngine
+from PySide6.QtTest import QTest
 from PySide6.QtQuickControls2 import QQuickStyle
 
 from markitdowngui.core.settings import SettingsManager
 from markitdowngui.ui_qml.controller import AppController
 
 
-def test_main_qml_loads_with_controller_context(monkeypatch, tmp_path):
+def _relative_luminance(hex_color: str) -> float:
+    channels = [int(hex_color[index : index + 2], 16) / 255 for index in (1, 3, 5)]
+    linear_channels = [
+        channel / 12.92
+        if channel <= 0.04045
+        else ((channel + 0.055) / 1.055) ** 2.4
+        for channel in channels
+    ]
+    return (
+        0.2126 * linear_channels[0]
+        + 0.7152 * linear_channels[1]
+        + 0.0722 * linear_channels[2]
+    )
+
+
+def _contrast_ratio(foreground: str, background: str) -> float:
+    foreground_luminance = _relative_luminance(foreground)
+    background_luminance = _relative_luminance(background)
+    lighter, darker = sorted((foreground_luminance, background_luminance), reverse=True)
+    return (lighter + 0.05) / (darker + 0.05)
+
+
+def _load_main_qml(monkeypatch, tmp_path):
     monkeypatch.setenv("QT_QPA_PLATFORM", "offscreen")
     QGuiApplication.setHighDpiScaleFactorRoundingPolicy(
         Qt.HighDpiScaleFactorRoundingPolicy.PassThrough
@@ -37,13 +60,40 @@ def test_main_qml_loads_with_controller_context(monkeypatch, tmp_path):
     )
     engine.load(QUrl.fromLocalFile(str(qml_path)))
 
+    assert len(engine.rootObjects()) == 1
+    return app, controller, engine, engine.rootObjects()[0]
+
+
+def _close_main_qml(app, controller, engine):
+    controller.shutdown()
+    for root in engine.rootObjects():
+        root.close()
+    app.processEvents()
+
+
+def _find_by_property(root, property_name, value):
+    matches = [
+        item
+        for item in root.findChildren(QObject)
+        if item.property(property_name) == value
+    ]
+    assert len(matches) == 1
+    return matches[0]
+
+
+def _accessible_name(item):
+    interface = QAccessible.queryAccessibleInterface(item)
+    assert interface is not None
+    return interface.text(QAccessible.Text.Name)
+
+
+def test_main_qml_loads_with_controller_context(monkeypatch, tmp_path):
+    app, controller, engine, _ = _load_main_qml(monkeypatch, tmp_path)
+
     try:
         assert len(engine.rootObjects()) == 1
     finally:
-        controller.shutdown()
-        for root in engine.rootObjects():
-            root.close()
-        app.processEvents()
+        _close_main_qml(app, controller, engine)
 
 
 def test_light_olive_tokens_do_not_leak_into_component_defaults():
@@ -72,3 +122,239 @@ def test_ocr_fallback_selector_is_provider_independent():
     assert main_text.index(fallback_marker) < main_text.index(glm_panel_marker)
     assert 'visible: app.ocrEnabled && app.ocrProvider !== "azure_tesseract"' in main_text
     assert "model: root.ocrFallbackLabels()" in main_text
+
+
+def test_workspace_confirms_before_discarding_unsaved_results():
+    main_text = (
+        Path(__file__).resolve().parents[2]
+        / "markitdowngui"
+        / "qml"
+        / "Main.qml"
+    ).read_text(encoding="utf-8")
+
+    assert "id: discardResultsDialog" in main_text
+    assert "function onDiscardResultsRequested(actionDescription)" in main_text
+    assert "app.cancelPendingResultDiscard()" in main_text
+    assert "app.discardPendingResults()" in main_text
+    assert "onClicked: app.backToQueue()" in main_text
+    assert "onClicked: app.startNew()" in main_text
+    assert "onClosing: close => close.accepted = app.requestShutdown()" in main_text
+    assert "function onCloseApproved()" in main_text
+
+
+def test_workspace_keeps_conversion_controls_with_progressive_results():
+    main_text = (
+        Path(__file__).resolve().parents[2]
+        / "markitdowngui"
+        / "qml"
+        / "Main.qml"
+    ).read_text(encoding="utf-8")
+
+    assert main_text.count('text: "Stop after current"') == 2
+    assert "id: activeResultControls" in main_text
+    assert "visible: app.converting" in main_text
+
+
+def test_workspace_clear_shortcut_does_not_steal_text_input_focus():
+    main_text = (
+        Path(__file__).resolve().parents[2]
+        / "markitdowngui"
+        / "qml"
+        / "Main.qml"
+    ).read_text(encoding="utf-8")
+
+    clear_shortcut = main_text[main_text.index('sequence: "Ctrl+L"') :]
+
+    assert (
+        "enabled: root.pageIndex === 0 && !app.converting && !root.focusedTextControl()"
+        in clear_shortcut
+    )
+    assert "onActivated: app.clearQueue()" in clear_shortcut
+
+
+def test_workspace_clear_shortcut_respects_url_field_focus(monkeypatch, tmp_path):
+    app, controller, engine, root = _load_main_qml(monkeypatch, tmp_path)
+
+    try:
+        assert controller.addUrl("https://example.com")
+        url_fields = [
+            item
+            for item in root.findChildren(QObject)
+            if item.property("placeholderText") in {"Add webpage URL", "Paste webpage URL"}
+        ]
+        assert len(url_fields) == 1
+        url_field = url_fields[0]
+        url_field.forceActiveFocus()
+        app.processEvents()
+
+        QTest.keyClick(root, Qt.Key_L, Qt.ControlModifier)
+        app.processEvents()
+
+        assert controller.queue_model.sources() == ["https://example.com"]
+
+        workspace_buttons = [
+            item
+            for item in root.findChildren(QObject)
+            if item.property("text") == "Add webpage" and item.property("iconName") == "link"
+        ]
+        assert len(workspace_buttons) == 1
+        workspace_button = workspace_buttons[0]
+        workspace_button.forceActiveFocus()
+        app.processEvents()
+        QTest.keyClick(root, Qt.Key_L, Qt.ControlModifier)
+        app.processEvents()
+
+        assert controller.queue_model.sources() == []
+    finally:
+        _close_main_qml(app, controller, engine)
+
+
+def test_settings_controls_have_explicit_accessible_names():
+    main_text = (
+        Path(__file__).resolve().parents[2]
+        / "markitdowngui"
+        / "qml"
+        / "Main.qml"
+    ).read_text(encoding="utf-8")
+
+    expected_names = (
+        'Accessible.name: "Application theme"',
+        'Accessible.name: "Primary OCR provider"',
+        'Accessible.name: "Fallback OCR provider"',
+        'Accessible.name: "GLM-OCR mode"',
+        'Accessible.name: "GLM-OCR Ollama host"',
+        'Accessible.name: "GLM-OCR Ollama port"',
+        'Accessible.name: "GLM-OCR Ollama model"',
+        'Accessible.name: "GLM-OCR SDK server endpoint"',
+        'Accessible.name: "HTTP OCR endpoint"',
+        'Accessible.name: "HTTP OCR model"',
+        'Accessible.name: "HTTP OCR timeout in seconds"',
+        'Accessible.name: "HTTP OCR API key environment variable"',
+        'Accessible.name: "Dismiss update notification"',
+    )
+
+    for accessible_name in expected_names:
+        assert accessible_name in main_text
+
+    assert (
+        'Accessible.name: app.ocrProvider === "glmocr" ? "Fallback Azure endpoint" : "Azure endpoint"'
+        in main_text
+    )
+    assert (
+        'Accessible.name: app.ocrProvider === "glmocr" ? "Fallback Tesseract languages" : "Tesseract languages"'
+        in main_text
+    )
+    assert (
+        'Accessible.name: app.ocrProvider === "glmocr" ? "Fallback Tesseract executable" : "Tesseract executable"'
+        in main_text
+    )
+
+
+def test_settings_accessible_names_are_exposed_to_qt_accessibility(monkeypatch, tmp_path):
+    app, controller, engine, root = _load_main_qml(monkeypatch, tmp_path)
+
+    try:
+        root.setProperty("pageIndex", 1)
+        controller.setOcrEnabled(True)
+        controller.setOcrProvider("azure_tesseract")
+        app.processEvents()
+
+        assert _accessible_name(
+            _find_by_property(root, "currentText", "Solarized Light")
+        ) == "Application theme"
+        assert _accessible_name(
+            _find_by_property(root, "currentText", "Azure + Tesseract")
+        ) == "Primary OCR provider"
+        assert _accessible_name(
+            _find_by_property(
+                root,
+                "placeholderText",
+                "https://example.cognitiveservices.azure.com/",
+            )
+        ) == "Azure endpoint"
+        assert _accessible_name(
+            _find_by_property(root, "placeholderText", "eng or eng+deu")
+        ) == "Tesseract languages"
+        assert _accessible_name(
+            _find_by_property(root, "placeholderText", "Optional executable path")
+        ) == "Tesseract executable"
+
+        controller.setOcrProvider("glmocr")
+        controller.setGlmocrMode("ollama")
+        app.processEvents()
+
+        assert _accessible_name(
+            _find_by_property(root, "currentText", "GLM-OCR")
+        ) == "Primary OCR provider"
+        assert _accessible_name(_find_by_property(root, "currentText", "None")) == (
+            "Fallback OCR provider"
+        )
+        assert _accessible_name(_find_by_property(root, "currentText", "Ollama")) == (
+            "GLM-OCR mode"
+        )
+        assert _accessible_name(
+            _find_by_property(root, "placeholderText", "127.0.0.1")
+        ) == "GLM-OCR Ollama host"
+        assert _accessible_name(
+            _find_by_property(root, "value", 11434)
+        ) == "GLM-OCR Ollama port"
+        assert _accessible_name(
+            _find_by_property(root, "placeholderText", "glm-ocr:latest")
+        ) == "GLM-OCR Ollama model"
+
+        controller.setOcrProvider("http")
+        app.processEvents()
+
+        assert _accessible_name(
+            _find_by_property(root, "placeholderText", "http://127.0.0.1:8000/ocr")
+        ) == "HTTP OCR endpoint"
+        assert _accessible_name(
+            _find_by_property(root, "placeholderText", "surya, doctr, paddleocr, ...")
+        ) == "HTTP OCR model"
+        assert _accessible_name(_find_by_property(root, "value", 300)) == (
+            "HTTP OCR timeout in seconds"
+        )
+        assert _accessible_name(
+            _find_by_property(root, "placeholderText", "OCR_HTTP_API_KEY")
+        ) == "HTTP OCR API key environment variable"
+    finally:
+        _close_main_qml(app, controller, engine)
+
+
+def test_light_theme_warning_and_error_tokens_meet_normal_text_contrast():
+    main_text = (
+        Path(__file__).resolve().parents[2]
+        / "markitdowngui"
+        / "qml"
+        / "Main.qml"
+    ).read_text(encoding="utf-8")
+
+    assert 'danger: dark ? Qt.color("#E8949C") : Qt.color("#C82624")' in main_text
+    assert 'warning: dark ? Qt.color("#EBCB8B") : Qt.color("#7A5900")' in main_text
+    assert _contrast_ratio("#7A5900", "#FFFCF0") >= 4.5
+    assert _contrast_ratio("#C82624", "#FFF2F0") >= 4.5
+    assert _contrast_ratio("#C82624", "#F7F0D8") >= 4.5
+
+
+def test_light_theme_runtime_palette_meets_normal_text_contrast(monkeypatch, tmp_path):
+    app, controller, engine, root = _load_main_qml(monkeypatch, tmp_path)
+
+    try:
+        controller.setThemeMode("light")
+        app.processEvents()
+        colors = root.property("colors")
+        if hasattr(colors, "toVariant"):
+            colors = colors.toVariant()
+
+        def color_name(name):
+            return colors[name].name()
+
+        assert _contrast_ratio(color_name("text"), color_name("window")) >= 4.5
+        assert _contrast_ratio(color_name("muted"), color_name("surface")) >= 4.5
+        assert _contrast_ratio(color_name("warning"), color_name("surface")) >= 4.5
+        assert _contrast_ratio(color_name("danger"), QColor("#FFF2F0").name()) >= 4.5
+        assert _contrast_ratio(color_name("success"), QColor("#EEF8F0").name()) >= 4.5
+        assert _contrast_ratio(color_name("onAction"), color_name("action")) >= 4.5
+        assert _contrast_ratio(color_name("onAccent"), color_name("danger")) >= 4.5
+    finally:
+        _close_main_qml(app, controller, engine)


### PR DESCRIPTION
## Summary
Hardens the desktop conversion workflow and aligns supporting documentation and dependency notices.

## Why
Improve conversion reliability, prevent accidental loss of unsaved results, and make exported Markdown assets safer to replace.

## Key Changes
- Stream conversion results into the UI with retry and cancellation safeguards.
- Use transactional Markdown and asset writes, preserving existing files on failures.
- Add unsaved-result confirmation, update-notification controls, and supporting QML coverage.
- Clarify licensing and third-party notices.

## Testing
- `uv sync --extra test --locked && QT_QPA_PLATFORM=offscreen uv run pytest -q` — 265 passed.
- Clean merge simulation with `origin/main`; merged tree test suite — 266 passed.
- Merged-tree QML load smoke — 11 passed.

## Breaking Changes
None

## Follow-ups
Run platform release-package builds before publishing a release.