### PR TITLE
feat(pdf): add opt-in fast digital PDF conversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ More screenshots:
 - Save modes: export as one combined file or separate files.
 - Quick actions: copy Markdown, save output, retry failed conversions, back to queue, start over.
 - Optional OCR for scanned PDFs and image files, with selectable `Azure + Tesseract`, `GLM-OCR`, and generic `HTTP OCR` providers.
+- Opt-in fast local conversion for clear digital PDFs using `pdf-inspector`; scanned, mixed, uncertain, and encoding-problem PDFs continue through the existing conversion and OCR path.
 - Settings for output folder, save mode, source-folder saves, OCR, and theme mode (light/dark/system).
 - Help view with project links, OCR references, conversion references, and keyboard shortcuts.
 
@@ -79,6 +80,7 @@ pip install -e .[dev]
 ### OCR Notes
 
 - OCR is optional and disabled by default.
+- **Fast PDF conversion** is optional and disabled by default. Enable it from the conversion controls for text-based PDFs where speed matters. It is bypassed when preserving PDF images, and it falls back to the established PDF pipeline when the document is scanned, mixed, uncertain, or has encoding issues.
 - `Azure + Tesseract` uses Azure Document Intelligence first when configured, then Tesseract as its local fallback.
 - `GLM-OCR` is available as a separate OCR provider for PDFs and images. It can fall back to another configured provider if selected in Settings.
 - `HTTP OCR` is a generic integration point for local or self-hosted OCR servers. The app sends a multipart `POST` with a `file` part, optional `model` field, and optional `Authorization: Bearer ...` header read from the configured environment variable. JSON responses can use `markdown`, `text`, `result`, `content`, or `output`; plain text responses are used directly.

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -25,6 +25,7 @@ terms.
 
 - MarkItDown: MIT License.
 - markitdown-pdf-images: MIT License.
+- pdf-inspector: MIT License.
 - Docling Core and Docling Parse: MIT License for the codebases; any model usage
   remains subject to the applicable model licences.
 - GLM-OCR Python package: Apache-2.0 License.

--- a/markitdowngui/build_config.py
+++ b/markitdowngui/build_config.py
@@ -40,6 +40,8 @@ OPTIONAL_HIDDENIMPORTS = (
     "markitdown_pdf_images.ocr",
     "markitdown_pdf_images.pipeline",
     "markitdown_pdf_images.vector",
+    "pdf_inspector",
+    "pdf_inspector.pdf_inspector",
     "pypdfium2",
     "pypdfium2_raw",
     "pytesseract",

--- a/markitdowngui/core/conversion.py
+++ b/markitdowngui/core/conversion.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from itertools import islice
 import base64
+import logging
 import mimetypes
 import os
 import shutil
@@ -12,6 +13,7 @@ from pathlib import Path
 from urllib.parse import quote
 
 import requests
+from pdf_inspector import process_pdf
 
 from PySide6.QtCore import QThread, Signal
 
@@ -47,6 +49,8 @@ BACKEND_LOCAL = "local"
 BACKEND_NATIVE = "native"
 BACKEND_DOCX_IMAGES = "docx-images"
 BACKEND_PDF_IMAGES = "pdf-images"
+BACKEND_PDF_INSPECTOR = "pdf-inspector"
+PDF_INSPECTOR_MIN_CONFIDENCE = 0.9
 OCR_PROVIDER_AZURE_TESSERACT = "azure_tesseract"
 OCR_PROVIDER_GLMOCR = "glmocr"
 OCR_PROVIDER_HTTP = "http"
@@ -144,6 +148,7 @@ class ConversionOptions:
     """User-controlled conversion behavior."""
 
     ocr_enabled: bool = False
+    fast_pdf_conversion: bool = False
     preserve_pdf_images: bool = False
     preserve_docx_images: bool = False
     ocr_provider: str = OCR_PROVIDER_AZURE_TESSERACT
@@ -185,6 +190,10 @@ class ConversionOptions:
     @property
     def normalized_preserve_pdf_images(self) -> bool:
         return bool(self.preserve_pdf_images)
+
+    @property
+    def normalized_fast_pdf_conversion(self) -> bool:
+        return bool(self.fast_pdf_conversion)
 
     @property
     def normalized_preserve_docx_images(self) -> bool:
@@ -665,6 +674,11 @@ def convert_file_with_details(
     if extension == PDF_EXTENSION and effective_options.normalized_preserve_pdf_images:
         return _convert_pdf_with_preserved_images(file_path, effective_options)
 
+    if extension == PDF_EXTENSION and effective_options.normalized_fast_pdf_conversion:
+        fast_outcome = _try_convert_pdf_with_pdf_inspector(file_path)
+        if fast_outcome is not None:
+            return fast_outcome
+
     if extension == DOCX_EXTENSION and effective_options.normalized_preserve_docx_images:
         return _convert_docx_with_preserved_images(file_path, effective_options)
 
@@ -692,6 +706,63 @@ def convert_file_with_details(
         ),
         backend=BACKEND_NATIVE,
     )
+
+
+def _try_convert_pdf_with_pdf_inspector(file_path: str) -> ConversionOutcome | None:
+    """Return a trusted fast PDF result, or None so the established path can continue.
+
+    pdf-inspector is deliberately an opt-in accelerator. It only takes ownership
+    of digital PDFs when its classification and output indicate a safe result;
+    scanned, mixed, uncertain, and encoding-problem PDFs retain the existing
+    MarkItDown and OCR behaviour.
+    """
+    try:
+        result = process_pdf(file_path)
+    except Exception as exc:
+        logging.warning("Fast PDF conversion fell back for %s: %s", file_path, exc)
+        return None
+
+    pdf_type = str(getattr(result, "pdf_type", "")).strip().lower()
+    if pdf_type != "text_based":
+        logging.warning(
+            "Fast PDF conversion fell back for %s: pdf-inspector classified it as %s",
+            file_path,
+            pdf_type or "unknown",
+        )
+        return None
+    if bool(getattr(result, "has_encoding_issues", True)):
+        logging.warning(
+            "Fast PDF conversion fell back for %s: pdf-inspector found encoding issues",
+            file_path,
+        )
+        return None
+
+    try:
+        confidence = float(getattr(result, "confidence", 0.0))
+    except (TypeError, ValueError):
+        logging.warning(
+            "Fast PDF conversion fell back for %s: pdf-inspector returned invalid confidence",
+            file_path,
+        )
+        return None
+    if confidence < PDF_INSPECTOR_MIN_CONFIDENCE:
+        logging.warning(
+            "Fast PDF conversion fell back for %s: confidence %.2f is below %.2f",
+            file_path,
+            confidence,
+            PDF_INSPECTOR_MIN_CONFIDENCE,
+        )
+        return None
+
+    markdown = getattr(result, "markdown", None)
+    if not isinstance(markdown, str) or not markdown.strip():
+        logging.warning(
+            "Fast PDF conversion fell back for %s: pdf-inspector returned no Markdown",
+            file_path,
+        )
+        return None
+
+    return ConversionOutcome(markdown=markdown, backend=BACKEND_PDF_INSPECTOR)
 
 
 def convert_file(file_path: str, options: ConversionOptions | None = None) -> str:

--- a/markitdowngui/core/conversion.py
+++ b/markitdowngui/core/conversion.py
@@ -13,7 +13,6 @@ from pathlib import Path
 from urllib.parse import quote
 
 import requests
-from pdf_inspector import process_pdf
 
 from PySide6.QtCore import QThread, Signal
 
@@ -51,6 +50,7 @@ BACKEND_DOCX_IMAGES = "docx-images"
 BACKEND_PDF_IMAGES = "pdf-images"
 BACKEND_PDF_INSPECTOR = "pdf-inspector"
 PDF_INSPECTOR_MIN_CONFIDENCE = 0.9
+process_pdf = None
 OCR_PROVIDER_AZURE_TESSERACT = "azure_tesseract"
 OCR_PROVIDER_GLMOCR = "glmocr"
 OCR_PROVIDER_HTTP = "http"
@@ -716,39 +716,49 @@ def _try_convert_pdf_with_pdf_inspector(file_path: str) -> ConversionOutcome | N
     scanned, mixed, uncertain, and encoding-problem PDFs retain the existing
     MarkItDown and OCR behaviour.
     """
+    global process_pdf
+
+    if process_pdf is None:
+        try:
+            from pdf_inspector import process_pdf as _process_pdf
+        except ImportError as exc:
+            logging.warning(
+                "Fast PDF conversion fell back: pdf-inspector is unavailable (%s)",
+                type(exc).__name__,
+            )
+            return None
+        process_pdf = _process_pdf
+
     try:
         result = process_pdf(file_path)
     except Exception as exc:
-        logging.warning("Fast PDF conversion fell back for %s: %s", file_path, exc)
+        logging.warning(
+            "Fast PDF conversion fell back: pdf-inspector raised %s",
+            type(exc).__name__,
+        )
         return None
 
     pdf_type = str(getattr(result, "pdf_type", "")).strip().lower()
     if pdf_type != "text_based":
         logging.warning(
-            "Fast PDF conversion fell back for %s: pdf-inspector classified it as %s",
-            file_path,
+            "Fast PDF conversion fell back: pdf-inspector classified it as %s",
             pdf_type or "unknown",
         )
         return None
     if bool(getattr(result, "has_encoding_issues", True)):
-        logging.warning(
-            "Fast PDF conversion fell back for %s: pdf-inspector found encoding issues",
-            file_path,
-        )
+        logging.warning("Fast PDF conversion fell back: pdf-inspector found encoding issues")
         return None
 
     try:
         confidence = float(getattr(result, "confidence", 0.0))
     except (TypeError, ValueError):
         logging.warning(
-            "Fast PDF conversion fell back for %s: pdf-inspector returned invalid confidence",
-            file_path,
+            "Fast PDF conversion fell back: pdf-inspector returned invalid confidence",
         )
         return None
     if confidence < PDF_INSPECTOR_MIN_CONFIDENCE:
         logging.warning(
-            "Fast PDF conversion fell back for %s: confidence %.2f is below %.2f",
-            file_path,
+            "Fast PDF conversion fell back: confidence %.2f is below %.2f",
             confidence,
             PDF_INSPECTOR_MIN_CONFIDENCE,
         )
@@ -756,10 +766,7 @@ def _try_convert_pdf_with_pdf_inspector(file_path: str) -> ConversionOutcome | N
 
     markdown = getattr(result, "markdown", None)
     if not isinstance(markdown, str) or not markdown.strip():
-        logging.warning(
-            "Fast PDF conversion fell back for %s: pdf-inspector returned no Markdown",
-            file_path,
-        )
+        logging.warning("Fast PDF conversion fell back: pdf-inspector returned no Markdown")
         return None
 
     return ConversionOutcome(markdown=markdown, backend=BACKEND_PDF_INSPECTOR)

--- a/markitdowngui/core/settings.py
+++ b/markitdowngui/core/settings.py
@@ -161,6 +161,14 @@ class SettingsManager:
         """Set whether OCR is enabled."""
         self.settings.setValue('ocrEnabled', enabled)
 
+    def get_fast_pdf_conversion(self) -> bool:
+        """Get whether eligible digital PDFs use pdf-inspector first."""
+        return bool(self.settings.value('fastPdfConversion', False, type=bool))
+
+    def set_fast_pdf_conversion(self, enabled: bool) -> None:
+        """Set whether eligible digital PDFs use pdf-inspector first."""
+        self.settings.setValue('fastPdfConversion', enabled)
+
     def get_preserve_pdf_images(self) -> bool:
         """Get whether PDF image preservation is enabled by default."""
         return bool(self.settings.value('preservePdfImages', False, type=bool))

--- a/markitdowngui/qml/Main.qml
+++ b/markitdowngui/qml/Main.qml
@@ -1205,6 +1205,25 @@ ApplicationWindow {
                         }
 
                         ThemeToggleRow {
+                            id: fastPdfConversionToggle
+                            title: "Fast PDF conversion"
+                            detail: "Use the fast local parser for clear digital PDFs. Mixed, scanned, or uncertain PDFs keep the existing conversion path."
+                            enabled: !app.converting && !app.preservePdfImages
+                            checked: app.fastPdfConversion
+                            textColor: colors.text
+                            mutedTextColor: colors.muted
+                            Layout.fillWidth: true
+                        }
+
+                        Connections {
+                            target: fastPdfConversionToggle
+
+                            function onToggled(enabled) {
+                                app.setFastPdfConversion(enabled)
+                            }
+                        }
+
+                        ThemeToggleRow {
                             title: "Preserve PDF images"
                             detail: "Extract PDF page images and keep relative asset links on export."
                             enabled: !app.converting

--- a/markitdowngui/qml/components/ToggleRow.qml
+++ b/markitdowngui/qml/components/ToggleRow.qml
@@ -57,7 +57,7 @@ RowLayout {
         Accessible.role: Accessible.Switch
         Accessible.name: root.title
         Accessible.description: root.detail
-        onToggled: root.toggled(checked)
+        onToggled: root.toggled(switchControl.checked)
 
         indicator: Rectangle {
             implicitWidth: 46
@@ -104,4 +104,3 @@ RowLayout {
         }
     }
 }
-

--- a/markitdowngui/ui_qml/controller.py
+++ b/markitdowngui/ui_qml/controller.py
@@ -360,6 +360,10 @@ class AppController(QObject):
         return self.settings.get_ocr_enabled()
 
     @Property(bool, notify=settingsChanged)
+    def fastPdfConversion(self) -> bool:
+        return self.settings.get_fast_pdf_conversion()
+
+    @Property(bool, notify=settingsChanged)
     def preservePdfImages(self) -> bool:
         return self.settings.get_preserve_pdf_images()
 
@@ -951,6 +955,11 @@ class AppController(QObject):
         self.settings.set_ocr_enabled(enabled)
         self.settingsChanged.emit()
         self.diagnosticsChanged.emit()
+
+    @Slot(bool)
+    def setFastPdfConversion(self, enabled: bool) -> None:
+        self.settings.set_fast_pdf_conversion(enabled)
+        self.settingsChanged.emit()
 
     @Slot(bool)
     def setPreservePdfImages(self, enabled: bool) -> None:
@@ -1929,6 +1938,7 @@ class AppController(QObject):
 
         return ConversionOptions(
             ocr_enabled=self.settings.get_ocr_enabled(),
+            fast_pdf_conversion=self.settings.get_fast_pdf_conversion(),
             preserve_pdf_images=preserve_pdf_images,
             preserve_docx_images=preserve_docx_images,
             ocr_provider=self.settings.get_ocr_provider(),

--- a/markitdowngui/ui_qml/models.py
+++ b/markitdowngui/ui_qml/models.py
@@ -42,6 +42,7 @@ class ResultItem:
             "native": "Native",
             "docx-images": "DOCX assets",
             "pdf-images": "PDF assets",
+            "pdf-inspector": "Fast PDF",
         }
         return labels.get(self.outcome.backend, self.outcome.backend or "Native")
 

--- a/markitdowngui/utils/settings_profile.py
+++ b/markitdowngui/utils/settings_profile.py
@@ -37,6 +37,7 @@ def build_settings_profile(
             },
             "conversion": {
                 "batchSize": settings.get_batch_size(),
+                "fastPdfConversion": settings.get_fast_pdf_conversion(),
                 "preservePdfImages": settings.get_preserve_pdf_images(),
                 "preserveDocxImages": settings.get_preserve_docx_images(),
             },
@@ -113,6 +114,8 @@ def apply_settings_profile(settings: SettingsManager, payload: dict[str, Any]) -
 
     if "batchSize" in conversion:
         settings.set_batch_size(_int_value(conversion["batchSize"]))
+    if "fastPdfConversion" in conversion:
+        settings.set_fast_pdf_conversion(_bool_value(conversion["fastPdfConversion"]))
     if "preservePdfImages" in conversion:
         settings.set_preserve_pdf_images(_bool_value(conversion["preservePdfImages"]))
     if "preserveDocxImages" in conversion:

--- a/markitdowngui/utils/support_bundle.py
+++ b/markitdowngui/utils/support_bundle.py
@@ -86,6 +86,7 @@ def build_sanitized_settings_snapshot(settings: SettingsManager) -> dict[str, An
         },
         "conversion": {
             "batchSize": settings.get_batch_size(),
+            "fastPdfConversion": settings.get_fast_pdf_conversion(),
             "preservePdfImages": settings.get_preserve_pdf_images(),
             "preserveDocxImages": settings.get_preserve_docx_images(),
         },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ requires-python = ">=3.10"
 dependencies = [
     "markitdown[az-doc-intel,docx,pdf,pptx,xls,xlsx]==0.1.6",
     "pypdfium2",
+    "pdf-inspector==0.2.6",
     "pytesseract",
     "pyside6>=6.8.2.1",
     "glmocr==0.1.4",

--- a/requirements.txt
+++ b/requirements.txt
@@ -121,6 +121,8 @@ pandas==2.3.0
     # via
     #   docling-core
     #   markitdown
+pdf-inspector==0.2.6
+    # via markitdowngui (pyproject.toml)
 pdfminer-six==20251230
     # via
     #   markitdown

--- a/tests/core/test_conversion.py
+++ b/tests/core/test_conversion.py
@@ -1,5 +1,6 @@
 import importlib
 import io
+import logging
 import sys
 import types
 
@@ -234,6 +235,60 @@ def test_fast_pdf_conversion_falls_back_to_ocr_when_enabled(monkeypatch, convers
     )
 
     assert outcome is expected
+
+
+def test_fast_pdf_conversion_falls_back_when_dependency_is_unavailable(
+    monkeypatch,
+    conversion,
+):
+    monkeypatch.setattr(conversion, "process_pdf", None)
+    monkeypatch.setitem(sys.modules, "pdf_inspector", None)
+    monkeypatch.setattr(
+        conversion,
+        "_convert_with_markitdown",
+        lambda *_args, **_kwargs: "native fallback",
+    )
+
+    outcome = conversion.convert_file_with_details(
+        "report.pdf",
+        conversion.ConversionOptions(fast_pdf_conversion=True),
+    )
+
+    assert outcome.markdown == "native fallback"
+    assert outcome.backend == conversion.BACKEND_NATIVE
+
+
+def test_fast_pdf_conversion_fallback_logs_do_not_include_source_path(
+    monkeypatch,
+    conversion,
+    caplog,
+):
+    source_path = "/private/customer-records/report.pdf"
+    _install_fake_pdf_inspector(
+        monkeypatch,
+        conversion,
+        lambda _file_path: types.SimpleNamespace(
+            pdf_type="scanned",
+            confidence=1.0,
+            has_encoding_issues=False,
+            markdown="# OCR needed",
+        ),
+    )
+    monkeypatch.setattr(
+        conversion,
+        "_convert_with_markitdown",
+        lambda *_args, **_kwargs: "native fallback",
+    )
+
+    with caplog.at_level(logging.WARNING):
+        outcome = conversion.convert_file_with_details(
+            source_path,
+            conversion.ConversionOptions(fast_pdf_conversion=True),
+        )
+
+    assert outcome.backend == conversion.BACKEND_NATIVE
+    assert source_path not in caplog.text
+    assert "classified it as scanned" in caplog.text
 
 
 def test_fast_pdf_conversion_keeps_image_preservation_authoritative(

--- a/tests/core/test_conversion.py
+++ b/tests/core/test_conversion.py
@@ -54,6 +54,10 @@ def _install_fake_pdf_images(monkeypatch, convert_pdf):
     monkeypatch.setitem(sys.modules, "markitdown_pdf_images", package)
 
 
+def _install_fake_pdf_inspector(monkeypatch, conversion, process_pdf):
+    monkeypatch.setattr(conversion, "process_pdf", process_pdf)
+
+
 def _install_fake_docx_dependencies(
     monkeypatch,
     *,
@@ -129,6 +133,134 @@ def test_convert_pdf_without_preserve_images_keeps_native_path(monkeypatch, conv
 
     assert result == "native pdf text"
     assert calls == [("scan.pdf", False)]
+
+
+def test_fast_pdf_conversion_uses_pdf_inspector_for_trusted_text_pdf(monkeypatch, conversion):
+    native_calls = []
+
+    def process_pdf(file_path):
+        assert file_path == "report.pdf"
+        return types.SimpleNamespace(
+            pdf_type="text_based",
+            confidence=0.99,
+            has_encoding_issues=False,
+            markdown="# Fast report",
+        )
+
+    def native_convert(*args, **kwargs):
+        native_calls.append((args, kwargs))
+        return "native fallback"
+
+    _install_fake_pdf_inspector(monkeypatch, conversion, process_pdf)
+    monkeypatch.setattr(conversion, "_convert_with_markitdown", native_convert)
+
+    outcome = conversion.convert_file_with_details(
+        "report.pdf",
+        conversion.ConversionOptions(fast_pdf_conversion=True),
+    )
+
+    assert outcome.markdown == "# Fast report"
+    assert outcome.backend == conversion.BACKEND_PDF_INSPECTOR
+    assert native_calls == []
+
+
+@pytest.mark.parametrize(
+    "result",
+    [
+        types.SimpleNamespace(
+            pdf_type="scanned",
+            confidence=1.0,
+            has_encoding_issues=False,
+            markdown="# OCR needed",
+        ),
+        types.SimpleNamespace(
+            pdf_type="text_based",
+            confidence=0.5,
+            has_encoding_issues=False,
+            markdown="# Low confidence",
+        ),
+        types.SimpleNamespace(
+            pdf_type="text_based",
+            confidence=1.0,
+            has_encoding_issues=True,
+            markdown="# Encoding issue",
+        ),
+        types.SimpleNamespace(
+            pdf_type="text_based",
+            confidence=1.0,
+            has_encoding_issues=False,
+            markdown="  ",
+        ),
+    ],
+)
+def test_fast_pdf_conversion_falls_back_for_untrusted_result(
+    monkeypatch,
+    conversion,
+    result,
+):
+    _install_fake_pdf_inspector(monkeypatch, conversion, lambda _file_path: result)
+    monkeypatch.setattr(
+        conversion,
+        "_convert_with_markitdown",
+        lambda *_args, **_kwargs: "native fallback",
+    )
+
+    outcome = conversion.convert_file_with_details(
+        "report.pdf",
+        conversion.ConversionOptions(fast_pdf_conversion=True),
+    )
+
+    assert outcome.markdown == "native fallback"
+    assert outcome.backend == conversion.BACKEND_NATIVE
+
+
+def test_fast_pdf_conversion_falls_back_to_ocr_when_enabled(monkeypatch, conversion):
+    _install_fake_pdf_inspector(
+        monkeypatch,
+        conversion,
+        lambda _file_path: types.SimpleNamespace(
+            pdf_type="mixed",
+            confidence=1.0,
+            has_encoding_issues=False,
+            markdown="# Partial text",
+        ),
+    )
+    expected = conversion.ConversionOutcome("ocr fallback", backend="local")
+    monkeypatch.setattr(conversion, "_convert_pdf_with_ocr", lambda *_args: expected)
+
+    outcome = conversion.convert_file_with_details(
+        "mixed.pdf",
+        conversion.ConversionOptions(ocr_enabled=True, fast_pdf_conversion=True),
+    )
+
+    assert outcome is expected
+
+
+def test_fast_pdf_conversion_keeps_image_preservation_authoritative(
+    monkeypatch,
+    conversion,
+):
+    _install_fake_pdf_inspector(
+        monkeypatch,
+        conversion,
+        lambda _file_path: pytest.fail("fast parser must not run when preserving images"),
+    )
+    expected = conversion.ConversionOutcome("with assets", backend="pdf-images")
+    monkeypatch.setattr(
+        conversion,
+        "_convert_pdf_with_preserved_images",
+        lambda *_args: expected,
+    )
+
+    outcome = conversion.convert_file_with_details(
+        "illustrated.pdf",
+        conversion.ConversionOptions(
+            fast_pdf_conversion=True,
+            preserve_pdf_images=True,
+        ),
+    )
+
+    assert outcome is expected
 
 
 def test_convert_url_uses_defuddle_http_api(monkeypatch, conversion):

--- a/tests/core/test_settings.py
+++ b/tests/core/test_settings.py
@@ -110,6 +110,10 @@ def test_ocr_settings(settings_manager):
     settings_manager.set_ocr_enabled(True)
     assert settings_manager.get_ocr_enabled()
 
+    assert not settings_manager.get_fast_pdf_conversion()
+    settings_manager.set_fast_pdf_conversion(True)
+    assert settings_manager.get_fast_pdf_conversion()
+
     assert not settings_manager.get_preserve_pdf_images()
     settings_manager.set_preserve_pdf_images(True)
     assert settings_manager.get_preserve_pdf_images()

--- a/tests/test_build_config.py
+++ b/tests/test_build_config.py
@@ -22,6 +22,7 @@ def test_build_hiddenimports_includes_charset_normalizer_mypyc_runtime():
     assert "azure.ai.documentintelligence.aio" in hiddenimports
     assert "glmocr.api" in hiddenimports
     assert "markitdown_pdf_images.converter" in hiddenimports
+    assert "pdf_inspector.pdf_inspector" in hiddenimports
     assert calls[:2] == ["markitdown", "charset_normalizer"]
 
 

--- a/tests/ui_qml/test_controller.py
+++ b/tests/ui_qml/test_controller.py
@@ -1123,6 +1123,15 @@ def test_controller_diagnostic_readiness_updates_after_ocr_change(controller):
     assert changes
 
 
+def test_controller_builds_fast_pdf_conversion_option(controller):
+    controller.setFastPdfConversion(True)
+
+    options = controller._build_conversion_options(create_asset_root=False)
+
+    assert controller.fastPdfConversion is True
+    assert options.fast_pdf_conversion is True
+
+
 def test_diagnostic_readiness_does_not_create_temp_asset_root(controller, monkeypatch):
     controller.setPreservePdfImages(True)
     monkeypatch.setattr(

--- a/tests/ui_qml/test_models.py
+++ b/tests/ui_qml/test_models.py
@@ -39,6 +39,16 @@ def test_result_model_exposes_backend_and_failure_state():
     assert model.data(index, ResultModel.WordCountRole) == 2
 
 
+def test_result_model_labels_fast_pdf_results():
+    model = ResultModel()
+    model.add_result(
+        "C:/tmp/report.pdf",
+        ConversionOutcome(markdown="fast text", backend="pdf-inspector"),
+    )
+
+    assert model.data(model.index(0, 0), ResultModel.BackendRole) == "Fast PDF"
+
+
 def test_result_model_add_result_preserves_existing_completed_items():
     model = ResultModel()
     model.add_result(
@@ -75,4 +85,3 @@ def test_result_model_removes_only_sources_that_are_being_retried():
 
     assert model.rowCount() == 1
     assert model.item_at(0).source == "C:/tmp/ok.pdf"
-

--- a/tests/ui_qml/test_qml_load.py
+++ b/tests/ui_qml/test_qml_load.py
@@ -1,8 +1,9 @@
 from pathlib import Path
 
-from PySide6.QtCore import QCoreApplication, QObject, QSettings, QUrl, Qt
+from PySide6.QtCore import QCoreApplication, QObject, QPoint, QSettings, QUrl, Qt
 from PySide6.QtGui import QAccessible, QColor, QGuiApplication
 from PySide6.QtQml import QQmlApplicationEngine
+from PySide6.QtQuick import QQuickItem
 from PySide6.QtTest import QTest
 from PySide6.QtQuickControls2 import QQuickStyle
 
@@ -122,6 +123,56 @@ def test_ocr_fallback_selector_is_provider_independent():
     assert main_text.index(fallback_marker) < main_text.index(glm_panel_marker)
     assert 'visible: app.ocrEnabled && app.ocrProvider !== "azure_tesseract"' in main_text
     assert "model: root.ocrFallbackLabels()" in main_text
+
+
+def test_workspace_exposes_fast_pdf_conversion_control():
+    qml_root = Path(__file__).resolve().parents[2] / "markitdowngui" / "qml"
+    main_text = (qml_root / "Main.qml").read_text(encoding="utf-8")
+
+    assert 'title: "Fast PDF conversion"' in main_text
+    assert "checked: app.fastPdfConversion" in main_text
+    assert "target: fastPdfConversionToggle" in main_text
+    assert "function onToggled(enabled)" in main_text
+    assert "app.setFastPdfConversion(enabled)" in main_text
+
+
+def test_fast_pdf_conversion_toggle_updates_controller(monkeypatch, tmp_path):
+    app, controller, engine, root = _load_main_qml(monkeypatch, tmp_path)
+
+    try:
+        controller.addFiles([str(tmp_path / "digital.pdf")])
+        app.processEvents()
+        toggle = _find_by_property(root, "title", "Fast PDF conversion")
+        switch = next(
+            item
+            for item in toggle.findChildren(QQuickItem)
+            if item.property("checked") is not None
+        )
+        position = switch.mapToScene(switch.boundingRect().center())
+
+        QTest.mouseClick(
+            root,
+            Qt.MouseButton.LeftButton,
+            Qt.KeyboardModifier.NoModifier,
+            QPoint(round(position.x()), round(position.y())),
+        )
+        app.processEvents()
+
+        assert controller.fastPdfConversion is True
+    finally:
+        _close_main_qml(app, controller, engine)
+
+
+def test_toggle_row_emits_the_switch_value():
+    toggle_row = (
+        Path(__file__).resolve().parents[2]
+        / "markitdowngui"
+        / "qml"
+        / "components"
+        / "ToggleRow.qml"
+    ).read_text(encoding="utf-8")
+
+    assert "onToggled: root.toggled(switchControl.checked)" in toggle_row
 
 
 def test_workspace_confirms_before_discarding_unsaved_results():

--- a/tests/utils/test_settings_profile.py
+++ b/tests/utils/test_settings_profile.py
@@ -38,6 +38,7 @@ def test_settings_profile_exports_portable_settings_without_recent_paths(tmp_pat
     assert profile["schema"] == 1
     assert profile["generatedAt"] == "2026-01-02T03:04:05+00:00"
     assert profile["settings"]["appearance"]["themeMode"] == "dark"
+    assert profile["settings"]["conversion"]["fastPdfConversion"] is False
     assert profile["settings"]["ocr"]["provider"] == "http"
     assert profile["settings"]["ocr"]["httpEndpoint"] == "http://localhost:8000/ocr"
     assert profile["settings"]["updates"]["notificationsEnabled"] is False
@@ -61,6 +62,7 @@ def test_settings_profile_import_applies_safe_settings(tmp_path):
             },
             "conversion": {
                 "batchSize": 8,
+                "fastPdfConversion": True,
                 "preservePdfImages": True,
                 "preserveDocxImages": True,
             },
@@ -92,6 +94,7 @@ def test_settings_profile_import_applies_safe_settings(tmp_path):
     assert settings.get_save_to_source_folder() is True
     assert settings.get_save_mode() is False
     assert settings.get_batch_size() == 8
+    assert settings.get_fast_pdf_conversion() is True
     assert settings.get_preserve_pdf_images() is True
     assert settings.get_preserve_docx_images() is True
     assert settings.get_ocr_enabled() is True
@@ -125,6 +128,7 @@ def test_settings_profile_import_parses_string_booleans(tmp_path):
                     "combinedSaveMode": "false",
                 },
                 "conversion": {
+                    "fastPdfConversion": "true",
                     "preservePdfImages": "true",
                     "preserveDocxImages": "false",
                 },
@@ -136,6 +140,7 @@ def test_settings_profile_import_parses_string_booleans(tmp_path):
 
     assert settings.get_save_to_source_folder() is False
     assert settings.get_save_mode() is False
+    assert settings.get_fast_pdf_conversion() is True
     assert settings.get_preserve_pdf_images() is True
     assert settings.get_preserve_docx_images() is False
     assert settings.get_ocr_enabled() is True

--- a/tests/utils/test_support_bundle.py
+++ b/tests/utils/test_support_bundle.py
@@ -26,6 +26,7 @@ def test_sanitized_settings_snapshot_excludes_raw_paths(tmp_path):
     settings.set_http_ocr_endpoint("https://ocr.example/private")
     settings.set_docintel_endpoint("https://azure.example/private")
     settings.set_tesseract_path(str(tmp_path / "tesseract.exe"))
+    settings.set_fast_pdf_conversion(True)
 
     snapshot = support_bundle.build_sanitized_settings_snapshot(settings)
     encoded = json.dumps(snapshot)
@@ -33,6 +34,7 @@ def test_sanitized_settings_snapshot_excludes_raw_paths(tmp_path):
     assert snapshot["output"]["defaultOutputFolderConfigured"] is True
     assert snapshot["output"]["recentFilesCount"] == 1
     assert snapshot["output"]["recentOutputsCount"] == 1
+    assert snapshot["conversion"]["fastPdfConversion"] is True
     assert snapshot["ocr"]["httpEndpointConfigured"] is True
     assert snapshot["ocr"]["docintelEndpointConfigured"] is True
     assert str(tmp_path) not in encoded

--- a/uv.lock
+++ b/uv.lock
@@ -759,6 +759,7 @@ dependencies = [
     { name = "glmocr" },
     { name = "markitdown", extra = ["az-doc-intel", "docx", "pdf", "pptx", "xls", "xlsx"] },
     { name = "markitdown-pdf-images" },
+    { name = "pdf-inspector" },
     { name = "pypdfium2" },
     { name = "pyside6" },
     { name = "pytesseract" },
@@ -781,6 +782,7 @@ requires-dist = [
     { name = "markitdown", extras = ["az-doc-intel", "docx", "pdf", "pptx", "xls", "xlsx"], specifier = "==0.1.6" },
     { name = "markitdown-pdf-images", git = "https://github.com/imadreamerboy/markitdown-pdf-images.git?rev=b1e2fafec9545acd5713974a32a2f7fe7a37b7f4" },
     { name = "markitdowngui", extras = ["test"], marker = "extra == 'dev'" },
+    { name = "pdf-inspector", specifier = "==0.2.6" },
     { name = "pyinstaller", marker = "extra == 'dev'" },
     { name = "pypdfium2" },
     { name = "pyside6", specifier = ">=6.8.2.1" },
@@ -1064,6 +1066,19 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/15/aa/3fc3181d12b95da71f5c2537c3e3b3af6ab3a8c392ab41ebb766e0929bc6/pandas-2.3.0-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1a881bc1309f3fce34696d07b00f13335c41f5f5a8770a33b09ebe23261cfc67", size = 11966182, upload-time = "2025-06-05T03:27:47.652Z" },
     { url = "https://files.pythonhosted.org/packages/37/e7/e12f2d9b0a2c4a2cc86e2aabff7ccfd24f03e597d770abfa2acd313ee46b/pandas-2.3.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:e1991bbb96f4050b09b5f811253c4f3cf05ee89a589379aa36cd623f21a31d6f", size = 12547686, upload-time = "2025-06-06T00:00:26.142Z" },
     { url = "https://files.pythonhosted.org/packages/39/c2/646d2e93e0af70f4e5359d870a63584dacbc324b54d73e6b3267920ff117/pandas-2.3.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:bb3be958022198531eb7ec2008cfc78c5b1eed51af8600c6c5d9160d89d8d249", size = 13231847, upload-time = "2025-06-05T03:27:51.465Z" },
+]
+
+[[package]]
+name = "pdf-inspector"
+version = "0.2.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8d/7a/525ee06cad5c46d8aa7357c15b8f72c60e803246f3b7e24523e602f01f6d/pdf_inspector-0.2.6.tar.gz", hash = "sha256:5bb387f39bf7a93b02b49188b670b9798f8ccc7e58f68eee5883a512aa05ceb2", size = 1481660, upload-time = "2026-07-31T23:16:55.116Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8c/dc/9963c292151dd82678dddb63e1c640ec420e37d400f304dca2780c6d11a3/pdf_inspector-0.2.6-cp38-abi3-macosx_10_12_x86_64.whl", hash = "sha256:c935a354facbfb935e88cb4f3f60fd158402f2af661c1a25a3da328eb21f19fb", size = 2719559, upload-time = "2026-07-31T23:16:46.721Z" },
+    { url = "https://files.pythonhosted.org/packages/72/70/2049766fec20c2ee6c01776cc2b7b8599fc9cf2d48e8940419600f65d4a0/pdf_inspector-0.2.6-cp38-abi3-macosx_11_0_arm64.whl", hash = "sha256:d2b2aaa95b242da38630bbd0644ffe9a929466f9c4e6406d6f1957b59b413d08", size = 2630319, upload-time = "2026-07-31T23:16:48.871Z" },
+    { url = "https://files.pythonhosted.org/packages/45/f3/be670e07df2eb57a1adaeb63b1011d17061fd3036370d9f903984eda94e4/pdf_inspector-0.2.6-cp38-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:79ba33b224029b68edbd30e7f6dc034f730663749ba0bea12e5873b31435ca28", size = 2808903, upload-time = "2026-07-31T23:16:50.368Z" },
+    { url = "https://files.pythonhosted.org/packages/59/af/be72ab2bd310b6532e4311cf06175eb722802ccea29dbd9281f66c645bd8/pdf_inspector-0.2.6-cp38-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:df76dd100504b705ce92ef2c668f152f05277d942abd94a7d3f252cb5448d56d", size = 2903593, upload-time = "2026-07-31T23:16:51.906Z" },
+    { url = "https://files.pythonhosted.org/packages/84/8a/22e2bf7413444036138f55a0c9f2b6420f7ef54b6a044755f4dbb3a7395b/pdf_inspector-0.2.6-cp38-abi3-win_amd64.whl", hash = "sha256:89814af887c5ff90f013702ba285ec8a4c5ae4e2ccbdb948f3e421f7c4b4f89d", size = 2550798, upload-time = "2026-07-31T23:16:53.64Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary\nAdds an opt-in pdf-inspector fast path for clear digital PDFs.\n\n## Why\nDigital PDFs can be converted faster locally while scanned, mixed, uncertain, or encoding-problem documents retain the established conversion and OCR path.\n\n## Key Changes\n- Add the opt-in Fast PDF conversion setting and QML control.\n- Route trusted text-based PDFs through pdf-inspector with confidence and encoding safeguards.\n- Preserve the existing image-preservation and OCR precedence.\n- Include packaged-app hidden imports, settings profiles, support snapshots, documentation, and third-party notice updates.\n- Add conversion, settings, controller, QML, packaging, profile, and support-bundle tests.\n\n## Testing\n- QT_QPA_PLATFORM=offscreen uv run pytest -q — 289 passed.\n- uv lock --check — passed.\n- git diff --check — passed.\n- PyInstaller macOS app build — passed.\n- Packaged GUI smoke test with a real digital PDF — reported the Fast PDF backend.\n\n## Breaking Changes\nNone\n\n## Follow-ups\nNone.